### PR TITLE
Add E2E encryption support for notification mirroring

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -101,6 +101,15 @@
   "enable_notification_mirroring_label": {
     "message": "Enable Notification Mirroring"
   },
+  "encryption_password_label": {
+    "message": "End-to-End Encryption Password:"
+  },
+  "encryption_password_placeholder": {
+    "message": "Optional - for encrypted features"
+  },
+  "encryption_help_text": {
+    "message": "Enable encryption for Notification Mirroring and SMS. Must be the same on all devices."
+  },
   "show_sms_shortcut_label": {
     "message": "Show Pushbullet SMS shortcut in popup"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -108,7 +108,7 @@
     "message": "Optional - for encrypted features"
   },
   "encryption_help_text": {
-    "message": "Enable encryption for Notification Mirroring and SMS. Must be the same on all devices."
+    "message": "Enable encryption for Notification Mirroring and SMS. Your password is never stored. Must be the same on all devices."
   },
   "show_sms_shortcut_label": {
     "message": "Show Pushbullet SMS shortcut in popup"

--- a/src/background.js
+++ b/src/background.js
@@ -402,6 +402,13 @@ async function connectWebSocket() {
     try {
       let data = JSON.parse(event.data);
       
+      // Check for encrypted ephemeral without configured crypto - graceful degradation
+      if (data.type === 'push' && data.push && data.push.encrypted === true && !pushbulletCrypto) {
+        // Silently ignore encrypted messages when encryption is not configured
+        console.log('Received encrypted ephemeral but encryption is not configured - ignoring');
+        return;
+      }
+      
       // Process encrypted ephemeral if applicable
       if (pushbulletCrypto && data.type === 'push' && data.push) {
         data = await pushbulletCrypto.processEphemeral(data);

--- a/src/background.js
+++ b/src/background.js
@@ -90,6 +90,7 @@ initializeBackgroundI18n().catch(error => {
 
 // Import crypto module
 importScripts('crypto.js');
+// @ts-ignore - PushbulletCrypto is loaded via importScripts
 
 // Initialize encryption if key is stored
 async function initializeEncryption() {

--- a/src/background.js
+++ b/src/background.js
@@ -6,6 +6,8 @@ let heartbeatTimer = null;
 let reconnectAttempts = 0;
 let maxReconnectAttempts = 5;
 let keepAliveIntervalId = null;
+let pushbulletCrypto = null;
+let userIden = null;
 
 // Context menu setup lock to prevent race conditions
 let isSettingUpContextMenus = false;
@@ -85,6 +87,30 @@ const CustomI18n = { getMessage, getCurrentLanguage, initializeI18n: initializeB
 initializeBackgroundI18n().catch(error => {
   console.warn('Initial i18n initialization failed, will use Chrome default:', error);
 });
+
+// Import crypto module
+importScripts('crypto.js');
+
+// Initialize encryption if password is set
+async function initializeEncryption() {
+  try {
+    const data = await chrome.storage.sync.get(['encryptionPassword', 'userIden']);
+    
+    if (data.encryptionPassword && data.userIden) {
+      if (!pushbulletCrypto) {
+        pushbulletCrypto = new PushbulletCrypto();
+      }
+      await pushbulletCrypto.initialize(data.encryptionPassword, data.userIden);
+      console.log('Encryption initialized successfully');
+    } else if (pushbulletCrypto) {
+      // Clear encryption if password is removed
+      pushbulletCrypto.clear();
+      pushbulletCrypto = null;
+    }
+  } catch (error) {
+    console.error('Failed to initialize encryption:', error);
+  }
+}
 
 // Network event listeners for immediate reconnection when network comes back
 // Note: In service workers, we rely on navigator.onLine checks in connectWebSocket instead of events
@@ -209,11 +235,16 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     case 'send_push':
       sendPush(message.data);
       break;
+    case 'encryption_updated':
+      initializeEncryption().then(() => {
+        sendResponse({ success: true });
+      });
+      return true; // Will respond asynchronously
   }
 });
 
 async function initializeExtension() {
-  const data = await chrome.storage.sync.get('accessToken');
+  const data = await chrome.storage.sync.get(['accessToken', 'encryptionPassword']);
   const localData = await chrome.storage.local.get('lastModified');
   accessToken = data.accessToken;
   
@@ -223,9 +254,38 @@ async function initializeExtension() {
   }
   
   if (accessToken) {
+    // Get user info to obtain iden for encryption
+    await getUserInfo();
+    
+    // Initialize encryption if password is set
+    if (data.encryptionPassword) {
+      await initializeEncryption();
+    }
+    
     connectWebSocket();
   } else {
     connectionStatus = 'disconnected';
+  }
+}
+
+async function getUserInfo() {
+  if (!accessToken) return;
+  
+  try {
+    const response = await fetch('https://api.pushbullet.com/v2/users/me', {
+      headers: {
+        'Access-Token': accessToken
+      }
+    });
+    
+    if (response.ok) {
+      const user = await response.json();
+      userIden = user.iden;
+      // Store user iden for encryption
+      await chrome.storage.sync.set({ userIden: user.iden });
+    }
+  } catch (error) {
+    console.error('Failed to get user info:', error);
   }
 }
 
@@ -317,9 +377,14 @@ async function connectWebSocket() {
     refreshPushList(true, false);
   };
   
-  ws.onmessage = (event) => {
+  ws.onmessage = async (event) => {
     try {
-      const data = JSON.parse(event.data);
+      let data = JSON.parse(event.data);
+      
+      // Process encrypted ephemeral if applicable
+      if (pushbulletCrypto && data.type === 'push' && data.push) {
+        data = await pushbulletCrypto.processEphemeral(data);
+      }
       
       if (data.type === 'nop') {
         startHeartbeatMonitor();

--- a/src/background.js
+++ b/src/background.js
@@ -91,19 +91,31 @@ initializeBackgroundI18n().catch(error => {
 // Import crypto module
 importScripts('crypto.js');
 
-// Initialize encryption if password is set
+// Initialize encryption if key is stored
 async function initializeEncryption() {
   try {
-    const data = await chrome.storage.sync.get(['encryptionPassword', 'userIden']);
+    // Get userIden to load the correct key
+    const syncData = await chrome.storage.sync.get('userIden');
+    if (!syncData.userIden) {
+      // No user logged in, clear any encryption
+      if (pushbulletCrypto) {
+        pushbulletCrypto.clear();
+        pushbulletCrypto = null;
+      }
+      return;
+    }
     
-    if (data.encryptionPassword && data.userIden) {
+    const keyName = `encryptionKey_${syncData.userIden}`;
+    const localData = await chrome.storage.local.get(keyName);
+    
+    if (localData[keyName]) {
       if (!pushbulletCrypto) {
         pushbulletCrypto = new PushbulletCrypto();
       }
-      await pushbulletCrypto.initialize(data.encryptionPassword, data.userIden);
+      await pushbulletCrypto.importKey(localData[keyName]);
       console.log('Encryption initialized successfully');
     } else if (pushbulletCrypto) {
-      // Clear encryption if password is removed
+      // Clear encryption if key is removed
       pushbulletCrypto.clear();
       pushbulletCrypto = null;
     }
@@ -205,6 +217,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   switch (message.type) {
     case 'token_updated':
       initializeBackgroundI18n().then(async () => {
+        // Check if token was removed (sign-out)
+        const data = await chrome.storage.sync.get('accessToken');
+        if (!data.accessToken) {
+          // Clear all encryption keys on sign-out
+          const localData = await chrome.storage.local.get(null);
+          const keysToRemove = Object.keys(localData).filter(key => key.startsWith('encryptionKey_'));
+          if (keysToRemove.length > 0) {
+            await chrome.storage.local.remove(keysToRemove);
+            console.log('Cleared encryption keys on sign-out');
+          }
+        }
         initializeExtension();
         await setupContextMenus();
       }).catch(async (error) => {
@@ -244,7 +267,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 async function initializeExtension() {
-  const data = await chrome.storage.sync.get(['accessToken', 'encryptionPassword']);
+  const data = await chrome.storage.sync.get('accessToken');
   const localData = await chrome.storage.local.get('lastModified');
   accessToken = data.accessToken;
   
@@ -257,10 +280,8 @@ async function initializeExtension() {
     // Get user info to obtain iden for encryption
     await getUserInfo();
     
-    // Initialize encryption if password is set
-    if (data.encryptionPassword) {
-      await initializeEncryption();
-    }
+    // Initialize encryption if key is stored
+    await initializeEncryption();
     
     connectWebSocket();
   } else {

--- a/src/background.js
+++ b/src/background.js
@@ -405,13 +405,19 @@ async function connectWebSocket() {
       // Check for encrypted ephemeral without configured crypto - graceful degradation
       if (data.type === 'push' && data.push && data.push.encrypted === true && !pushbulletCrypto) {
         // Silently ignore encrypted messages when encryption is not configured
-        console.log('Received encrypted ephemeral but encryption is not configured - ignoring');
+        console.warn('Received encrypted ephemeral but encryption is not configured - ignoring');
         return;
       }
       
       // Process encrypted ephemeral if applicable
       if (pushbulletCrypto && data.type === 'push' && data.push) {
         data = await pushbulletCrypto.processEphemeral(data);
+        
+        // Check if decryption failed (push is still encrypted)
+        if (data.push && data.push.encrypted === true) {
+          console.warn('Failed to decrypt ephemeral (wrong password?) - ignoring');
+          return;
+        }
       }
       
       if (data.type === 'nop') {

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -55,7 +55,7 @@ class PushbulletCrypto {
       passwordKey,
       { name: 'AES-GCM', length: 256 },
       true, // extractable for export
-      ['encrypt', 'decrypt']
+      ['decrypt']
     );
 
     return key;
@@ -85,53 +85,10 @@ class PushbulletCrypto {
       keyBuffer,
       { name: 'AES-GCM', length: 256 },
       true,
-      ['encrypt', 'decrypt']
+      ['decrypt']
     );
   }
 
-  /**
-   * Encrypt a message
-   * @param {object|string} message - Message to encrypt
-   * @returns {string} Base64 encoded encrypted message
-   */
-  async encrypt(message) {
-    if (!this.encryptionKey) {
-      throw new Error('Encryption not initialized');
-    }
-
-    // Convert message to JSON string if it's an object
-    const messageStr = typeof message === 'string' ? message : JSON.stringify(message);
-    const encoder = new TextEncoder();
-    const messageBuffer = encoder.encode(messageStr);
-
-    // Generate random IV (96 bits / 12 bytes)
-    const iv = crypto.getRandomValues(new Uint8Array(12));
-
-    // Encrypt the message
-    const encrypted = await crypto.subtle.encrypt(
-      {
-        name: 'AES-GCM',
-        iv: iv
-      },
-      this.encryptionKey,
-      messageBuffer
-    );
-
-    // Extract the tag (last 16 bytes) and ciphertext
-    const encryptedArray = new Uint8Array(encrypted);
-    const tag = encryptedArray.slice(-16);
-    const ciphertext = encryptedArray.slice(0, -16);
-
-    // Combine: version(1) + tag(16) + iv(12) + ciphertext
-    const version = new Uint8Array([49]); // '1' in ASCII
-    const combined = new Uint8Array(version.length + tag.length + iv.length + ciphertext.length);
-    combined.set(version, 0);
-    combined.set(tag, 1);
-    combined.set(iv, 17);
-    combined.set(ciphertext, 29);
-
-    return this.arrayBufferToBase64(combined.buffer);
-  }
 
   /**
    * Decrypt an encrypted message
@@ -229,23 +186,6 @@ class PushbulletCrypto {
     return ephemeral;
   }
 
-  /**
-   * Prepare data for encrypted sending
-   * @param {object} data - Data to encrypt
-   * @returns {object} Encrypted push object
-   */
-  async prepareEncryptedPush(data) {
-    if (!this.encryptionKey) {
-      throw new Error('Encryption not initialized');
-    }
-
-    const ciphertext = await this.encrypt(data);
-    
-    return {
-      encrypted: true,
-      ciphertext: ciphertext
-    };
-  }
 
   // Utility functions
   arrayBufferToBase64(buffer) {

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,0 +1,281 @@
+/**
+ * Pushbullet End-to-End Encryption Module
+ * Implements AES-256-GCM encryption with PBKDF2 key derivation
+ * Based on Pushbullet API documentation
+ */
+
+class PushbulletCrypto {
+  constructor() {
+    this.encryptionKey = null;
+    this.userIden = null;
+  }
+
+  /**
+   * Initialize encryption with user password and iden
+   * @param {string} password - User's encryption password
+   * @param {string} userIden - User's Pushbullet iden (used as salt)
+   */
+  async initialize(password, userIden) {
+    if (!password || !userIden) {
+      throw new Error('Password and user iden are required');
+    }
+    
+    this.userIden = userIden;
+    this.encryptionKey = await this.deriveKey(password, userIden);
+  }
+
+  /**
+   * Derive encryption key using PBKDF2
+   * @param {string} password - User's encryption password
+   * @param {string} salt - User's iden as salt
+   * @returns {CryptoKey} Derived encryption key
+   */
+  async deriveKey(password, salt) {
+    const encoder = new TextEncoder();
+    const passwordBuffer = encoder.encode(password);
+    const saltBuffer = encoder.encode(salt);
+
+    // Import password as a key
+    const passwordKey = await crypto.subtle.importKey(
+      'raw',
+      passwordBuffer,
+      'PBKDF2',
+      false,
+      ['deriveBits', 'deriveKey']
+    );
+
+    // Derive the actual encryption key using PBKDF2
+    const key = await crypto.subtle.deriveKey(
+      {
+        name: 'PBKDF2',
+        salt: saltBuffer,
+        iterations: 30000,
+        hash: 'SHA-256'
+      },
+      passwordKey,
+      { name: 'AES-GCM', length: 256 },
+      true, // extractable for export
+      ['encrypt', 'decrypt']
+    );
+
+    return key;
+  }
+
+  /**
+   * Export key to base64 for storage
+   * @returns {string} Base64 encoded key
+   */
+  async exportKey() {
+    if (!this.encryptionKey) {
+      throw new Error('Encryption not initialized');
+    }
+    
+    const exported = await crypto.subtle.exportKey('raw', this.encryptionKey);
+    return this.arrayBufferToBase64(exported);
+  }
+
+  /**
+   * Import key from base64
+   * @param {string} base64Key - Base64 encoded key
+   */
+  async importKey(base64Key) {
+    const keyBuffer = this.base64ToArrayBuffer(base64Key);
+    this.encryptionKey = await crypto.subtle.importKey(
+      'raw',
+      keyBuffer,
+      { name: 'AES-GCM', length: 256 },
+      true,
+      ['encrypt', 'decrypt']
+    );
+  }
+
+  /**
+   * Encrypt a message
+   * @param {object|string} message - Message to encrypt
+   * @returns {string} Base64 encoded encrypted message
+   */
+  async encrypt(message) {
+    if (!this.encryptionKey) {
+      throw new Error('Encryption not initialized');
+    }
+
+    // Convert message to JSON string if it's an object
+    const messageStr = typeof message === 'string' ? message : JSON.stringify(message);
+    const encoder = new TextEncoder();
+    const messageBuffer = encoder.encode(messageStr);
+
+    // Generate random IV (96 bits / 12 bytes)
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+
+    // Encrypt the message
+    const encrypted = await crypto.subtle.encrypt(
+      {
+        name: 'AES-GCM',
+        iv: iv
+      },
+      this.encryptionKey,
+      messageBuffer
+    );
+
+    // Extract the tag (last 16 bytes) and ciphertext
+    const encryptedArray = new Uint8Array(encrypted);
+    const tag = encryptedArray.slice(-16);
+    const ciphertext = encryptedArray.slice(0, -16);
+
+    // Combine: version(1) + tag(16) + iv(12) + ciphertext
+    const version = new Uint8Array([49]); // '1' in ASCII
+    const combined = new Uint8Array(version.length + tag.length + iv.length + ciphertext.length);
+    combined.set(version, 0);
+    combined.set(tag, 1);
+    combined.set(iv, 17);
+    combined.set(ciphertext, 29);
+
+    return this.arrayBufferToBase64(combined.buffer);
+  }
+
+  /**
+   * Decrypt an encrypted message
+   * @param {string} encryptedMessage - Base64 encoded encrypted message
+   * @returns {object|string} Decrypted message
+   */
+  async decrypt(encryptedMessage) {
+    if (!this.encryptionKey) {
+      throw new Error('Encryption not initialized');
+    }
+
+    const combined = new Uint8Array(this.base64ToArrayBuffer(encryptedMessage));
+
+    // Check version
+    if (combined[0] !== 49) { // '1' in ASCII
+      throw new Error('Invalid encryption version');
+    }
+
+    // Extract components
+    const tag = combined.slice(1, 17);
+    const iv = combined.slice(17, 29);
+    const ciphertext = combined.slice(29);
+
+    // Combine ciphertext and tag for decryption (GCM expects them together)
+    const encryptedData = new Uint8Array(ciphertext.length + tag.length);
+    encryptedData.set(ciphertext, 0);
+    encryptedData.set(tag, ciphertext.length);
+
+    // Decrypt
+    const decrypted = await crypto.subtle.decrypt(
+      {
+        name: 'AES-GCM',
+        iv: iv
+      },
+      this.encryptionKey,
+      encryptedData
+    );
+
+    // Convert to string
+    const decoder = new TextDecoder();
+    const decryptedStr = decoder.decode(decrypted);
+
+    // Try to parse as JSON, otherwise return as string
+    try {
+      return JSON.parse(decryptedStr);
+    } catch {
+      return decryptedStr;
+    }
+  }
+
+  /**
+   * Check if a push object is encrypted
+   * @param {object} push - Push object from Pushbullet
+   * @returns {boolean} True if encrypted
+   */
+  isEncrypted(push) {
+    return push && push.encrypted === true && push.ciphertext;
+  }
+
+  /**
+   * Process an ephemeral message (decrypt if encrypted)
+   * @param {object} ephemeral - Ephemeral object from WebSocket
+   * @returns {object} Processed ephemeral with decrypted data if applicable
+   */
+  async processEphemeral(ephemeral) {
+    if (!ephemeral || !ephemeral.push) {
+      return ephemeral;
+    }
+
+    // Check if the push is encrypted
+    if (this.isEncrypted(ephemeral.push)) {
+      if (!this.encryptionKey) {
+        console.warn('Received encrypted ephemeral but encryption is not configured');
+        return ephemeral;
+      }
+
+      try {
+        // Decrypt the ciphertext
+        const decryptedData = await this.decrypt(ephemeral.push.ciphertext);
+        
+        // Replace encrypted push with decrypted data
+        ephemeral.push = {
+          ...ephemeral.push,
+          ...decryptedData,
+          encrypted: false,
+          was_encrypted: true
+        };
+        delete ephemeral.push.ciphertext;
+      } catch (error) {
+        console.error('Failed to decrypt ephemeral:', error);
+        // Keep the original encrypted ephemeral
+      }
+    }
+
+    return ephemeral;
+  }
+
+  /**
+   * Prepare data for encrypted sending
+   * @param {object} data - Data to encrypt
+   * @returns {object} Encrypted push object
+   */
+  async prepareEncryptedPush(data) {
+    if (!this.encryptionKey) {
+      throw new Error('Encryption not initialized');
+    }
+
+    const ciphertext = await this.encrypt(data);
+    
+    return {
+      encrypted: true,
+      ciphertext: ciphertext
+    };
+  }
+
+  // Utility functions
+  arrayBufferToBase64(buffer) {
+    const bytes = new Uint8Array(buffer);
+    let binary = '';
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
+  }
+
+  base64ToArrayBuffer(base64) {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes.buffer;
+  }
+
+  /**
+   * Clear encryption key from memory
+   */
+  clear() {
+    this.encryptionKey = null;
+    this.userIden = null;
+  }
+}
+
+// Export for use in extension
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = PushbulletCrypto;
+}

--- a/src/options.html
+++ b/src/options.html
@@ -92,6 +92,16 @@
       color: var(--text-primary);
       font-size: 14px;
     }
+    .help-text {
+      display: block;
+      margin-top: 5px;
+      font-size: 12px;
+      color: #666;
+      line-height: 1.4;
+    }
+    .dark-mode .help-text {
+      color: #999;
+    }
     input[type="text"] { 
       width: 100%; 
       padding: 12px; 
@@ -344,6 +354,11 @@
           <div class="toggle-switch" id="notificationMirroringToggle">
             <div class="toggle-slider"></div>
           </div>
+        </div>
+        <div class="form-group">
+          <label for="encryptionPassword" data-i18n="encryption_password_label">End-to-End Encryption Password:</label>
+          <input type="password" id="encryptionPassword" placeholder="Optional - for encrypted features" data-i18n-placeholder="encryption_password_placeholder">
+          <small class="help-text" data-i18n="encryption_help_text">Enable encryption for Notification Mirroring and SMS. Must be the same on all devices.</small>
         </div>
         <div class="form-group" id="defaultTabGroup" style="display: none;">
           <label for="defaultTab" data-i18n="default_tab_label">Default tab in popup:</label>

--- a/src/options.html
+++ b/src/options.html
@@ -358,7 +358,7 @@
         <div class="form-group">
           <label for="encryptionPassword" data-i18n="encryption_password_label">End-to-End Encryption Password:</label>
           <input type="password" id="encryptionPassword" placeholder="Optional - for encrypted features" data-i18n-placeholder="encryption_password_placeholder">
-          <small class="help-text" data-i18n="encryption_help_text">Enable encryption for Notification Mirroring and SMS. Must be the same on all devices.</small>
+          <small class="help-text" data-i18n="encryption_help_text">Enable encryption for Notification Mirroring and SMS. Your password is never stored. Must be the same on all devices.</small>
         </div>
         <div class="form-group" id="defaultTabGroup" style="display: none;">
           <label for="defaultTab" data-i18n="default_tab_label">Default tab in popup:</label>
@@ -419,6 +419,7 @@
         <div id="appearanceStatus" class="status"></div>
       </div>
   </div>
+  <script src="crypto.js"></script>
   <script src="i18n.js"></script>
   <script src="options.js"></script>
 </body>

--- a/src/options.js
+++ b/src/options.js
@@ -16,6 +16,7 @@ document.addEventListener('DOMContentLoaded', function() {
   const hideBrowserPushesToggle = document.getElementById('hideBrowserPushesToggle');
   const showSmsShortcutCheckbox = document.getElementById('showSmsShortcut');
   const showSmsShortcutToggle = document.getElementById('showSmsShortcutToggle');
+  const encryptionPasswordInput = document.getElementById('encryptionPassword');
   const colorModeSelect = document.getElementById('colorMode');
   const languageModeSelect = document.getElementById('languageMode');
   const deviceSelectionStatus = document.getElementById('deviceSelectionStatus');
@@ -47,7 +48,7 @@ document.addEventListener('DOMContentLoaded', function() {
   let devices = [];
   let people = [];
 
-  chrome.storage.sync.get(['accessToken', 'remoteDeviceId', 'devices', 'people', 'autoOpenLinks', 'notificationMirroring', 'onlyBrowserPushes', 'hideBrowserPushes', 'showSmsShortcut', 'colorMode', 'languageMode', 'defaultTab'], function(data) {
+  chrome.storage.sync.get(['accessToken', 'remoteDeviceId', 'devices', 'people', 'autoOpenLinks', 'notificationMirroring', 'onlyBrowserPushes', 'hideBrowserPushes', 'showSmsShortcut', 'encryptionPassword', 'colorMode', 'languageMode', 'defaultTab'], function(data) {
     accessTokenInput.value = data.accessToken || '';
     devices = data.devices || [];
     people = data.people || [];
@@ -69,6 +70,11 @@ document.addEventListener('DOMContentLoaded', function() {
     // Load notification mirroring setting (default is false/off)
     notificationMirroringCheckbox.checked = data.notificationMirroring || false;
     updateNotificationMirroringToggleVisual();
+    
+    // Load encryption password (don't show the actual password, just indicate if set)
+    if (data.encryptionPassword) {
+      encryptionPasswordInput.placeholder = 'Password is set (enter new to change)';
+    }
     
     // Load only browser pushes setting (default is true/on)
     onlyBrowserPushesCheckbox.checked = data.onlyBrowserPushes !== false; // Default to true
@@ -310,7 +316,7 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 
   // Save Appearance Settings
-  saveAppearanceButton.addEventListener('click', function() {
+  saveAppearanceButton.addEventListener('click', async function() {
     const saveData = { 
       notificationMirroring: notificationMirroringCheckbox.checked,
       showSmsShortcut: showSmsShortcutCheckbox.checked,
@@ -318,6 +324,16 @@ document.addEventListener('DOMContentLoaded', function() {
       colorMode: colorModeSelect.value,
       defaultTab: defaultTabSelect.value
     };
+    
+    // Handle encryption password
+    const encryptionPassword = encryptionPasswordInput.value.trim();
+    if (encryptionPassword) {
+      // Only save if a new password is entered
+      saveData.encryptionPassword = encryptionPassword;
+      // Clear the input after saving
+      encryptionPasswordInput.value = '';
+      encryptionPasswordInput.placeholder = 'Password is set (enter new to change)';
+    }
 
     chrome.storage.sync.set(saveData, function() {
       // Check if language has changed
@@ -333,6 +349,12 @@ document.addEventListener('DOMContentLoaded', function() {
       } else {
         showAppearanceSaveSuccess();
       }
+      
+      // Notify background about encryption changes if password was updated
+      if (encryptionPassword) {
+        chrome.runtime.sendMessage({ type: 'encryption_updated' });
+      }
+      
       chrome.runtime.sendMessage({ type: 'token_updated' });
     });
   });

--- a/src/options.js
+++ b/src/options.js
@@ -48,7 +48,7 @@ document.addEventListener('DOMContentLoaded', function() {
   let devices = [];
   let people = [];
 
-  chrome.storage.sync.get(['accessToken', 'remoteDeviceId', 'devices', 'people', 'autoOpenLinks', 'notificationMirroring', 'onlyBrowserPushes', 'hideBrowserPushes', 'showSmsShortcut', 'encryptionPassword', 'colorMode', 'languageMode', 'defaultTab'], function(data) {
+  chrome.storage.sync.get(['accessToken', 'remoteDeviceId', 'devices', 'people', 'autoOpenLinks', 'notificationMirroring', 'onlyBrowserPushes', 'hideBrowserPushes', 'showSmsShortcut', 'userIden', 'colorMode', 'languageMode', 'defaultTab'], function(data) {
     accessTokenInput.value = data.accessToken || '';
     devices = data.devices || [];
     people = data.people || [];
@@ -71,9 +71,14 @@ document.addEventListener('DOMContentLoaded', function() {
     notificationMirroringCheckbox.checked = data.notificationMirroring || false;
     updateNotificationMirroringToggleVisual();
     
-    // Load encryption password (don't show the actual password, just indicate if set)
-    if (data.encryptionPassword) {
-      encryptionPasswordInput.placeholder = 'Password is set (enter new to change)';
+    // Check if encryption key is already set (stored locally)
+    if (data.userIden) {
+      const keyName = `encryptionKey_${data.userIden}`;
+      chrome.storage.local.get(keyName, function(localData) {
+        if (localData[keyName]) {
+          encryptionPasswordInput.placeholder = 'Password is set (enter new to change)';
+        }
+      });
     }
     
     // Load only browser pushes setting (default is true/on)
@@ -325,14 +330,37 @@ document.addEventListener('DOMContentLoaded', function() {
       defaultTab: defaultTabSelect.value
     };
     
-    // Handle encryption password
+    // Handle encryption password - derive key and store locally
     const encryptionPassword = encryptionPasswordInput.value.trim();
     if (encryptionPassword) {
-      // Only save if a new password is entered
-      saveData.encryptionPassword = encryptionPassword;
-      // Clear the input after saving
-      encryptionPasswordInput.value = '';
-      encryptionPasswordInput.placeholder = 'Password is set (enter new to change)';
+      // Get userIden from sync storage to derive the key
+      chrome.storage.sync.get('userIden', async function(userData) {
+        if (userData.userIden) {
+          try {
+            // Import crypto module functionality
+            const pbCrypto = new PushbulletCrypto();
+            await pbCrypto.initialize(encryptionPassword, userData.userIden);
+            const derivedKey = await pbCrypto.exportKey();
+            
+            // Store derived key locally (not synced), namespaced by user
+            const keyName = `encryptionKey_${userData.userIden}`;
+            await chrome.storage.local.set({ [keyName]: derivedKey });
+            
+            // Clear the input and update placeholder
+            encryptionPasswordInput.value = '';
+            encryptionPasswordInput.placeholder = 'Password is set (enter new to change)';
+            
+            // Notify background about encryption changes
+            chrome.runtime.sendMessage({ type: 'encryption_updated' });
+          } catch (error) {
+            console.error('Failed to derive encryption key:', error);
+            showAppearanceSaveError();
+          }
+        } else {
+          console.error('User iden not found - please retrieve devices first');
+          showAppearanceSaveError();
+        }
+      });
     }
 
     chrome.storage.sync.set(saveData, function() {
@@ -348,11 +376,6 @@ document.addEventListener('DOMContentLoaded', function() {
         });
       } else {
         showAppearanceSaveSuccess();
-      }
-      
-      // Notify background about encryption changes if password was updated
-      if (encryptionPassword) {
-        chrome.runtime.sendMessage({ type: 'encryption_updated' });
       }
       
       chrome.runtime.sendMessage({ type: 'token_updated' });


### PR DESCRIPTION
This PR adds the ability to decrypt encrypted notifications from other Pushbullet devices (see https://blog.pushbullet.com/2015/08/11/end-to-end-encryption/ for more).

  - Added a password field in the options page to set up E2E encryption
  - Implements AES-256-GCM decryption using the Web Crypto API (no external dependencies)
  - Automatically decrypts incoming encrypted notifications when a password is configured
  - Gracefully handles encrypted messages when no password is set (just ignores them)