### PR TITLE
Allow to notify and show pushes for a certain device from the devices list

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -313,5 +313,8 @@
   },
   "copied": {
     "message": "Copied"
+  },
+  "choose_other_devices_tip": {
+    "message": "Select which other devices to show notifications for. Hold Ctrl/Cmd to select multiple."
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Push Go for Pushbullet",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxM7/ABgzJriKpUyf7k2LD5KXYv9QSIoPc73fXC8f/HhdNVAHuKAAz/Nfzv+Z51LO21c7d7K2/aKRzUPXl4ZgxBO54Y4/DIBWkcnfhPTxBwggHRvzsrJFavBv/GSbuLW0BlddDkQwLKtRVWvKAmvUWAp41+C11eoomBT4Jo+n3Szmmz2AJ8xExZX+tAHAs3QrrqBfw1ejBWk82ss32+IVpOUewNl8TdOPlRtDW77O+dc+CsvxNS8Pm67ajgiZRDZiu6dxwqxgK4OnBrXW5v47MrnGyRdE5h7tFPUAY17t5eeh/n0v9FHdy1Dta45DJOeGjG5tEt0wgaR5N+cajsJP2QIDAQAB",
   "description": "A lightweight, open-source extension for cross-device pushes via Pushbullet API.",
   "homepage_url": "https://nemofq.github.io/pushbullet-go/",

--- a/src/options.html
+++ b/src/options.html
@@ -414,6 +414,13 @@
             <div class="toggle-slider"></div>
           </div>
         </div>
+        <div class="form-group" id="otherDeviceListGroup" style="display: none; margin-left: 24px; margin-bottom: 20px;">
+          <select id="otherDeviceIds" multiple>
+          </select>
+          <div class="tip" data-i18n="choose_other_devices_tip">
+            Select which other devices to show notifications for. Hold Ctrl/Cmd to select multiple.
+          </div>
+        </div>
         <div class="toggle-container" style="margin-left: 0px;">
           <label class="toggle-label">
             <span class="sub-option-icon">↳</span>


### PR DESCRIPTION
Following my feature request https://github.com/nemofq/pushbullet-go/issues/56, I ended up making the modification myself, and it seems to work.

There is now a new option to notify and display pushes for a specific device from the devices configured in the account, even if not Chrome.
I first tried using the Firefox profile so that pushes sent to Firefox would open and show in Chrome, then I created a new device in Pushbullet with the API (I think I might add an option to create a new custom device) and pushes sent from my mobile phone to that newly created device open in Chrome Push Go.

This is a valid workaround for PushBullet, treating all Chrome devices as a single device.

<img width="661" height="599" alt="image" src="https://github.com/user-attachments/assets/e310e492-f6fe-4a1a-b5ca-3d602ce3279e" />
