### PR TITLE
Add "Hide OS notifications" option to suppress desktop notifications

### DIFF
--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "إخفاء الإشعار عند الفتح التلقائي"
   },
+  "hide_os_notifications_label": {
+    "message": "إخفاء إشعارات النظام"
+  },
   "show_per_send_target_label": {
     "message": "إظهار محدد الهدف لكل إرسال في النافذة المنبثقة"
   },

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Скрий известието при автоматично отваряне"
   },
+  "hide_os_notifications_label": {
+    "message": "Скриване на системните известия"
+  },
   "show_per_send_target_label": {
     "message": "Показвай избор на цел за всяко изпращане в popup"
   },

--- a/src/_locales/ca/messages.json
+++ b/src/_locales/ca/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Amaga la notificació quan s'ha obert automàticament"
   },
+  "hide_os_notifications_label": {
+    "message": "Amaga les notificacions del sistema"
+  },
   "show_per_send_target_label": {
     "message": "Mostra el selector de destinatari per enviament al popup"
   },

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Skrýt oznámení při automatickém otevření"
   },
+  "hide_os_notifications_label": {
+    "message": "Skrýt systémová oznámení"
+  },
   "show_per_send_target_label": {
     "message": "Zobrazit výběr cíle pro každé odeslání v popup"
   },

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Skjul notifikation når den er auto-åbnet"
   },
+  "hide_os_notifications_label": {
+    "message": "Skjul systemnotifikationer"
+  },
   "show_per_send_target_label": {
     "message": "Vis målvælger per send i popup"
   },

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Benachrichtigung beim automatischen Öffnen ausblenden"
   },
+  "hide_os_notifications_label": {
+    "message": "Systembenachrichtigungen ausblenden"
+  },
   "show_per_send_target_label": {
     "message": "Zielauswahl pro Senden im Popup anzeigen"
   },

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Απόκρυψη ειδοποίησης όταν ανοίγει αυτόματα"
   },
+  "hide_os_notifications_label": {
+    "message": "Απόκρυψη ειδοποιήσεων συστήματος"
+  },
   "show_per_send_target_label": {
     "message": "Εμφάνιση επιλογέα στόχου ανά αποστολή στο popup"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -352,5 +352,8 @@
   },
   "hide_notification_on_auto_open_label": {
     "message": "Hide notification when it has auto-opened"
+  },
+  "hide_os_notifications_label": {
+    "message": "Hide OS notifications"
   }
 }

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Ocultar notificación cuando se abre automáticamente"
   },
+  "hide_os_notifications_label": {
+    "message": "Ocultar notificaciones del sistema"
+  },
   "show_per_send_target_label": {
     "message": "Mostrar selector de destino por envío en el popup"
   },

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Piilota ilmoitus automaattisen avauksen yhteydessä"
   },
+  "hide_os_notifications_label": {
+    "message": "Piilota käyttöjärjestelmän ilmoitukset"
+  },
   "show_per_send_target_label": {
     "message": "Näytä kohdevalitsin ponnahdusikkunassa"
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Masquer la notification lors de l'ouverture automatique"
   },
+  "hide_os_notifications_label": {
+    "message": "Masquer les notifications du système"
+  },
   "show_per_send_target_label": {
     "message": "Afficher le sélecteur de destination par envoi dans la popup"
   },

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "הסתר התראה כאשר היא נפתחת אוטומטית"
   },
+  "hide_os_notifications_label": {
+    "message": "הסתר התראות מערכת"
+  },
   "show_per_send_target_label": {
     "message": "הצג בורר יעד לכל שליחה בחלונית הקופצת"
   },

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Értesítés elrejtése automatikus megnyitáskor"
   },
+  "hide_os_notifications_label": {
+    "message": "Rendszerértesítések elrejtése"
+  },
   "show_per_send_target_label": {
     "message": "Céleszköz-választó megjelenítése a popup-ban"
   },

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Sembunyikan notifikasi saat dibuka otomatis"
   },
+  "hide_os_notifications_label": {
+    "message": "Sembunyikan notifikasi sistem"
+  },
   "show_per_send_target_label": {
     "message": "Tampilkan pemilih tujuan per-pengiriman di popup"
   },

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Nascondi notifica quando si apre automaticamente"
   },
+  "hide_os_notifications_label": {
+    "message": "Nascondi le notifiche del sistema"
+  },
   "show_per_send_target_label": {
     "message": "Mostra selettore destinazione per invio nel popup"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "自動で開いた時は通知を非表示"
   },
+  "hide_os_notifications_label": {
+    "message": "OS通知を非表示"
+  },
   "show_per_send_target_label": {
     "message": "ポップアップに送信ごとのターゲット選択を表示"
   },

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "자동으로 열릴 때 알림 숨기기"
   },
+  "hide_os_notifications_label": {
+    "message": "OS 알림 숨기기"
+  },
   "show_per_send_target_label": {
     "message": "팝업에서 전송별 대상 선택기 표시"
   },

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Verberg melding bij automatisch openen"
   },
+  "hide_os_notifications_label": {
+    "message": "Systeemmeldingen verbergen"
+  },
   "show_per_send_target_label": {
     "message": "Doelkiezer per verzending in popup tonen"
   },

--- a/src/_locales/no/messages.json
+++ b/src/_locales/no/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Skjul varsel ved automatisk åpning"
   },
+  "hide_os_notifications_label": {
+    "message": "Skjul systemvarsler"
+  },
   "show_per_send_target_label": {
     "message": "Vis per-sending målvelger i popup"
   },

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Ukryj powiadomienie przy automatycznym otwarciu"
   },
+  "hide_os_notifications_label": {
+    "message": "Ukryj powiadomienia systemowe"
+  },
   "show_per_send_target_label": {
     "message": "Pokaż wybór celu wysyłki w oknie popup"
   },

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Ocultar notificação quando abrir automaticamente"
   },
+  "hide_os_notifications_label": {
+    "message": "Ocultar notificações do sistema"
+  },
   "show_per_send_target_label": {
     "message": "Mostrar seletor de destino por envio no popup"
   },

--- a/src/_locales/pt_PT/messages.json
+++ b/src/_locales/pt_PT/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Ocultar notificação quando abre automaticamente"
   },
+  "hide_os_notifications_label": {
+    "message": "Ocultar notificações do sistema"
+  },
   "show_per_send_target_label": {
     "message": "Mostrar seletor de destino por envio no popup"
   },

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Ascunde notificarea la deschidere automată"
   },
+  "hide_os_notifications_label": {
+    "message": "Ascunde notificările sistemului"
+  },
   "show_per_send_target_label": {
     "message": "Afișează selector de destinație per-trimitere în popup"
   },

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Скрывать уведомление при автоматическом открытии"
   },
+  "hide_os_notifications_label": {
+    "message": "Скрывать системные уведомления"
+  },
   "show_per_send_target_label": {
     "message": "Показать выбор получателя для каждой отправки во всплывающем окне"
   },

--- a/src/_locales/sk/messages.json
+++ b/src/_locales/sk/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Skryť oznámenie pri automatickom otvorení"
   },
+  "hide_os_notifications_label": {
+    "message": "Skryť systémové oznámenia"
+  },
   "show_per_send_target_label": {
     "message": "Zobraziť výber cieľa pre každé odoslanie v popup"
   },

--- a/src/_locales/sl/messages.json
+++ b/src/_locales/sl/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Skrij obvestilo pri samodejnem odpiranju"
   },
+  "hide_os_notifications_label": {
+    "message": "Skrij sistemska obvestila"
+  },
   "show_per_send_target_label": {
     "message": "Prikaži izbirnik cilja za vsako pošiljanje v popup"
   },

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Dölj avisering vid automatisk öppning"
   },
+  "hide_os_notifications_label": {
+    "message": "Dölj systemaviseringar"
+  },
   "show_per_send_target_label": {
     "message": "Visa målväljare per sändning i popup"
   },

--- a/src/_locales/th/messages.json
+++ b/src/_locales/th/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "ซ่อนการแจ้งเตือนเมื่อเปิดอัตโนมัติ"
   },
+  "hide_os_notifications_label": {
+    "message": "ซ่อนการแจ้งเตือนของระบบ"
+  },
   "show_per_send_target_label": {
     "message": "แสดงตัวเลือกเป้าหมายต่อการส่งในป๊อปอัพ"
   },

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Otomatik açıldığında bildirimi gizle"
   },
+  "hide_os_notifications_label": {
+    "message": "İşletim sistemi bildirimlerini gizle"
+  },
   "show_per_send_target_label": {
     "message": "Gönderim başına hedef seçiciyi popup'ta göster"
   },

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Приховати сповіщення при автоматичному відкритті"
   },
+  "hide_os_notifications_label": {
+    "message": "Приховувати системні сповіщення"
+  },
   "show_per_send_target_label": {
     "message": "Показати вибір отримувача для кожного надсилання у спливаючому вікні"
   },

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "Ẩn thông báo khi tự động mở"
   },
+  "hide_os_notifications_label": {
+    "message": "Ẩn thông báo hệ điều hành"
+  },
   "show_per_send_target_label": {
     "message": "Hiển thị bộ chọn đích mỗi lần gửi trong popup"
   },

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "自动打开时隐藏通知"
   },
+  "hide_os_notifications_label": {
+    "message": "隐藏系统通知"
+  },
   "show_per_send_target_label": {
     "message": "在弹窗中显示每次发送的目标选择器"
   },

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -314,6 +314,9 @@
   "hide_notification_on_auto_open_label": {
     "message": "自動開啟時隱藏通知"
   },
+  "hide_os_notifications_label": {
+    "message": "隱藏系統通知"
+  },
   "show_per_send_target_label": {
     "message": "在彈出視窗中顯示單次傳送目標選擇器"
   },

--- a/src/background.js
+++ b/src/background.js
@@ -914,12 +914,16 @@ async function showNotificationForPush(push, autoOpenLinks = false, hideNotifica
     }
 
     // Check if require interaction is enabled for pushes
-    const requireInteractionData = await chrome.storage.local.get(['requireInteraction', 'requireInteractionPushes']);
-    if (requireInteractionData.requireInteraction && requireInteractionData.requireInteractionPushes) {
+    const notifPrefs = await chrome.storage.local.get(['requireInteraction', 'requireInteractionPushes', 'hideOsNotifications']);
+    if (notifPrefs.requireInteraction && notifPrefs.requireInteractionPushes) {
       notificationOptions.requireInteraction = true;
     }
 
-    chrome.notifications.create(`pushbullet-${push.iden}-${Date.now()}`, notificationOptions);
+    // Suppress the desktop/OS notification when the user has opted out; the
+    // push is still recorded in the popup and counted as unread.
+    if (!notifPrefs.hideOsNotifications) {
+      chrome.notifications.create(`pushbullet-${push.iden}-${Date.now()}`, notificationOptions);
+    }
 
     // Increment unread push count
     await incrementUnreadPushCount();
@@ -1056,15 +1060,19 @@ async function showMirrorNotification(notificationData) {
   }
 
   // Check if require interaction is enabled for mirrored notifications
-  const requireInteractionData = await chrome.storage.local.get(['requireInteraction', 'requireInteractionMirrored']);
-  if (requireInteractionData.requireInteraction && requireInteractionData.requireInteractionMirrored) {
+  const notifPrefs = await chrome.storage.local.get(['requireInteraction', 'requireInteractionMirrored', 'hideOsNotifications']);
+  if (notifPrefs.requireInteraction && notifPrefs.requireInteractionMirrored) {
     notificationOptions.requireInteraction = true;
   }
 
   // Use the UUID as notification ID for easy lookup
   const notificationId = `pushbullet-mirror-${notificationData.id}`;
 
-  chrome.notifications.create(notificationId, notificationOptions);
+  // Suppress the desktop/OS notification when the user has opted out; the
+  // mirrored notification is still recorded and counted as unread.
+  if (!notifPrefs.hideOsNotifications) {
+    chrome.notifications.create(notificationId, notificationOptions);
+  }
 
   // Play alert sound
   await playAlertSound();

--- a/src/options.html
+++ b/src/options.html
@@ -688,6 +688,13 @@
           <div class="toggle-slider"></div>
         </div>
       </div>
+      <div class="toggle-container">
+        <label class="toggle-label" data-i18n="hide_os_notifications_label">Hide OS notifications</label>
+        <input type="checkbox" id="hideOsNotifications" class="toggle-input">
+        <div class="toggle-switch" id="hideOsNotificationsToggle">
+          <div class="toggle-slider"></div>
+        </div>
+      </div>
     </div>
 
     <!-- Appearance Tab Content -->

--- a/src/options.js
+++ b/src/options.js
@@ -49,6 +49,8 @@ document.addEventListener('DOMContentLoaded', async function() {
   const defaultTabGroup = document.getElementById('defaultTabGroup');
   const playSoundOnNotificationCheckbox = document.getElementById('playSoundOnNotification');
   const playSoundOnNotificationToggle = document.getElementById('playSoundOnNotificationToggle');
+  const hideOsNotificationsCheckbox = document.getElementById('hideOsNotifications');
+  const hideOsNotificationsToggle = document.getElementById('hideOsNotificationsToggle');
   const otherDevicePickerEl = document.getElementById('otherDevicePicker');
   const otherDeviceListGroup = document.getElementById('otherDeviceListGroup');
   const showPerSendTargetCheckbox = document.getElementById('showPerSendTarget');
@@ -408,7 +410,7 @@ document.addEventListener('DOMContentLoaded', async function() {
     chrome.storage.sync.get(['accessToken', 'devices', 'people', 'userIden'], resolve);
   });
   const localData = await new Promise(resolve => {
-    chrome.storage.local.get(['remoteDeviceId', 'showPerSendTarget', 'autoOpenLinks', 'autoOpenOnResume', 'hideNotificationOnAutoOpen', 'notificationMirroring', 'onlyBrowserPushes', 'showOtherDevicePushes', 'showNoTargetPushes', 'hideBrowserPushes', 'showSmsShortcut', 'showQuickShare', 'requireInteraction', 'requireInteractionPushes', 'requireInteractionMirrored', 'closeAsDismiss', 'displayUnreadCounts', 'displayUnreadPushes', 'displayUnreadMirrored', 'colorMode', 'languageMode', 'defaultTab', 'playSoundOnNotification', 'selectedOtherDeviceIds'], resolve);
+    chrome.storage.local.get(['remoteDeviceId', 'showPerSendTarget', 'autoOpenLinks', 'autoOpenOnResume', 'hideNotificationOnAutoOpen', 'notificationMirroring', 'onlyBrowserPushes', 'showOtherDevicePushes', 'showNoTargetPushes', 'hideBrowserPushes', 'showSmsShortcut', 'showQuickShare', 'requireInteraction', 'requireInteractionPushes', 'requireInteractionMirrored', 'closeAsDismiss', 'displayUnreadCounts', 'displayUnreadPushes', 'displayUnreadMirrored', 'colorMode', 'languageMode', 'defaultTab', 'playSoundOnNotification', 'hideOsNotifications', 'selectedOtherDeviceIds'], resolve);
   });
   const data = { ...syncData, ...localData };
   
@@ -560,6 +562,10 @@ document.addEventListener('DOMContentLoaded', async function() {
     // Load play sound on notification setting (default is true/enabled)
     playSoundOnNotificationCheckbox.checked = data.playSoundOnNotification !== false; // Default to true
     updatePlaySoundOnNotificationToggleVisual();
+
+    // Load hide OS notifications setting (default is false/off)
+    hideOsNotificationsCheckbox.checked = data.hideOsNotifications || false; // Default to false
+    updateHideOsNotificationsToggleVisual();
     
     // Update conditional visibility for default tab option
     updateDefaultTabVisibility();
@@ -753,6 +759,11 @@ document.addEventListener('DOMContentLoaded', async function() {
   playSoundOnNotificationToggle.addEventListener('click', function() {
     playSoundOnNotificationCheckbox.checked = !playSoundOnNotificationCheckbox.checked;
     updatePlaySoundOnNotificationToggleVisual();
+  });
+
+  hideOsNotificationsToggle.addEventListener('click', function() {
+    hideOsNotificationsCheckbox.checked = !hideOsNotificationsCheckbox.checked;
+    updateHideOsNotificationsToggleVisual();
   });
 
   retrieveDevicesButton.addEventListener('click', async function() {
@@ -1071,7 +1082,8 @@ document.addEventListener('DOMContentLoaded', async function() {
       languageMode: languageList.getValue(),
       colorMode: colorModeDropdown.getValue(),
       defaultTab: defaultTabDropdown.getValue(),
-      playSoundOnNotification: playSoundOnNotificationCheckbox.checked
+      playSoundOnNotification: playSoundOnNotificationCheckbox.checked,
+      hideOsNotifications: hideOsNotificationsCheckbox.checked
     };
     
     // Handle encryption password - derive key and store locally
@@ -1139,7 +1151,8 @@ document.addEventListener('DOMContentLoaded', async function() {
       languageMode: saveData.languageMode,
       colorMode: saveData.colorMode,
       defaultTab: saveData.defaultTab,
-      playSoundOnNotification: saveData.playSoundOnNotification
+      playSoundOnNotification: saveData.playSoundOnNotification,
+      hideOsNotifications: saveData.hideOsNotifications
     };
     
     // Save to both storages
@@ -1417,6 +1430,14 @@ document.addEventListener('DOMContentLoaded', async function() {
       playSoundOnNotificationToggle.classList.add('active');
     } else {
       playSoundOnNotificationToggle.classList.remove('active');
+    }
+  }
+
+  function updateHideOsNotificationsToggleVisual() {
+    if (hideOsNotificationsCheckbox.checked) {
+      hideOsNotificationsToggle.classList.add('active');
+    } else {
+      hideOsNotificationsToggle.classList.remove('active');
     }
   }
   


### PR DESCRIPTION
When enabled, the extension no longer shows desktop/OS notification popups for incoming pushes or mirrored notifications.
Pushes are still recorded in the popup, unread counts still increment, and the alert sound still plays.

Default: off. Label translated into all 32 supported locales using Claude.
