### PR TITLE
notification body line-clamp; sticky clear history button

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -924,6 +924,11 @@
       color: var(--text-secondary);
       overflow-wrap: anywhere;
       line-height: 1.4;
+      display: -webkit-box;
+      overflow: hidden;
+      line-clamp: 3;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
     }
 
     .notification-actions {
@@ -1070,6 +1075,8 @@
       text-decoration: underline;
       display: block;
       width: fit-content;
+      position: sticky;
+      top: 0;
     }
 
     .clear-history-button:hover {


### PR DESCRIPTION
CSS (popup.html):
- Clamp notification body text to 3 lines (line-clamp) to keep rows tidy (currently whole body is shown).
- Make the plain "Clear history" button sticky to the top when scrolling.
