### PR TITLE
Fix notifications not correctly mirrored

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1169,8 +1169,8 @@ function isSameMirrorNotification(a, b) {
 // points (new mirrors, phone-side dismissals, extension-side dismissals,
 // popup deletes); like unreadCountOps, one queue keeps overlapping mutations
 // from reading the same starting array and dropping each other's writes.
-// mutate() gets the stored array and returns the next one, or falsy to skip
-// the write; the unread count is recomputed either way.
+// mutate() (sync or async) gets the stored array and returns the next one,
+// or falsy to skip the write; the unread count is recomputed either way.
 let mirrorStoreOps = Promise.resolve();
 
 function updateMirrorNotifications(mutate) {
@@ -1178,7 +1178,7 @@ function updateMirrorNotifications(mutate) {
     try {
       const data = await chrome.storage.local.get('mirrorNotifications');
       const notifications = data.mirrorNotifications || [];
-      const next = mutate(notifications);
+      const next = await mutate(notifications);
       if (next) {
         await chrome.storage.local.set({ mirrorNotifications: next });
       }
@@ -1204,9 +1204,18 @@ async function recomputeUnreadMirrorCount(notifications) {
 }
 
 async function markMirrorNotificationsRead() {
-  await chrome.storage.local.set({ lastMirrorReadTime: Date.now() / 1000 });
-  // Queue a no-op mutation so the count recomputes from a consistent snapshot
-  await updateMirrorNotifications(() => null);
+  // Opening the popup must always clear the badge: stamp the read time past
+  // every stored entry (not just the wall clock) inside the queue, so the
+  // recompute that follows is guaranteed to count zero even if an entry
+  // carries a futuristic timestamp from a skewed or corrected clock.
+  await updateMirrorNotifications(async (notifications) => {
+    const newest = notifications.reduce((max, n) => {
+      const t = n.receivedAt ?? n.created;
+      return t > max ? t : max;
+    }, 0);
+    await chrome.storage.local.set({ lastMirrorReadTime: Math.max(Date.now() / 1000, newest) });
+    return null;
+  });
 }
 
 async function handleMirrorNotification(mirrorData) {

--- a/src/background.js
+++ b/src/background.js
@@ -1216,13 +1216,15 @@ async function handleMirrorNotification(mirrorData) {
     }
   }
 
-  // Store in local storage (keep latest 100). A repeated mirror of an
-  // existing notification replaces its entry but keeps the stored UUID, so
-  // the Chrome notification and the dismissal flows stay addressable.
+  // Store in local storage (keep latest 100). A repeated mirror of a live
+  // notification replaces its entry in place, keeping the stored UUID so the
+  // Chrome notification and the dismissal flows stay addressable. Dismissed
+  // entries stay in the list as history; their Android slot starts over as a
+  // new entry.
   let isUpdate = false;
   await updateMirrorNotifications((notifications) => {
     const existingIndex = notifications.findIndex(n => isSameMirrorNotification(n, notificationData));
-    if (existingIndex !== -1) {
+    if (existingIndex !== -1 && !notifications[existingIndex].dismissed) {
       notificationData.id = notifications[existingIndex].id;
       notifications.splice(existingIndex, 1);
       isUpdate = true;
@@ -1487,11 +1489,21 @@ async function dismissMirrorNotification(notificationId) {
     
     if (response.ok) {
       console.log('Mirror notification dismissed successfully');
-      // Remove locally right away; the server echoes our own dismissal back
-      // over the websocket and handleMirrorDismissal must find nothing then.
-      await updateMirrorNotifications(notifications => notifications.filter(n => n.id !== uuid));
-      // Decrement unread mirror count when successfully dismissed
-      await decrementUnreadMirrorCount();
+      // Flag instead of removing: the entry stays in the popup list as
+      // history. Flipping dismissed exactly once (inside the queue) gates
+      // the unread decrement, so the server echo of this dismissal or a
+      // concurrent phone-side dismissal cannot decrement twice.
+      let flipped = false;
+      await updateMirrorNotifications((notifications) => {
+        const stored = notifications.find(n => n.id === uuid);
+        if (!stored || stored.dismissed) return null;
+        stored.dismissed = true;
+        flipped = true;
+        return notifications;
+      });
+      if (flipped) {
+        await decrementUnreadMirrorCount();
+      }
     } else {
       console.error('Failed to dismiss mirror notification:', response.statusText);
     }
@@ -1502,16 +1514,19 @@ async function dismissMirrorNotification(notificationId) {
 
 async function handleMirrorDismissal(dismissalData) {
   try {
-    // Find and remove the matching stored notification. Nothing found means
-    // the dismissal was already handled (e.g. the echo of our own dismissal).
+    // Flag the matching live notification as dismissed; it stays in the
+    // popup list as history. No live match means the dismissal was already
+    // handled (e.g. the echo of our own dismissal).
     let notification;
     await updateMirrorNotifications((notifications) => {
-      notification = notifications.find(n => isSameMirrorNotification(n, dismissalData));
-      return notification ? notifications.filter(n => n.id !== notification.id) : null;
+      notification = notifications.find(n => isSameMirrorNotification(n, dismissalData) && !n.dismissed);
+      if (!notification) return null;
+      notification.dismissed = true;
+      return notifications;
     });
 
     if (!notification) {
-      console.log('No matching notification found for dismissal');
+      console.log('No matching live notification found for dismissal');
       return;
     }
 

--- a/src/background.js
+++ b/src/background.js
@@ -447,7 +447,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       clearUnreadPushCount();
       return;
     case 'clear_unread_mirrors':
-      clearUnreadMirrorCount();
+      markMirrorNotificationsRead();
       return;
     case 'clear_push_history':
       clearPushHistory();
@@ -622,14 +622,22 @@ async function ensureDeviceDataFromServer() {
 
 async function initializeExtension() {
   const data = await chrome.storage.sync.get('accessToken');
-  const localData = await chrome.storage.local.get('lastModified');
+  const localData = await chrome.storage.local.get(['lastModified', 'lastMirrorReadTime']);
   accessToken = data.accessToken;
-  
+
   // Restore lastModified from storage to survive extension restarts
   if (localData.lastModified) {
     lastModified = localData.lastModified;
   }
-  
+
+  // First run after the update that introduced the derived unread count:
+  // treat entries stored before it as read so the badge does not light up
+  // retroactively.
+  if (localData.lastMirrorReadTime === undefined) {
+    await chrome.storage.local.set({ lastMirrorReadTime: Date.now() / 1000 });
+    await updateMirrorNotifications(() => null);
+  }
+
   if (accessToken) {
     // Initialize encryption if key is stored (userIden should be available from options page)
     await initializeEncryption();
@@ -1159,23 +1167,43 @@ function isSameMirrorNotification(a, b) {
 // popup deletes); like unreadCountOps, one queue keeps overlapping mutations
 // from reading the same starting array and dropping each other's writes.
 // mutate() gets the stored array and returns the next one, or falsy to skip
-// the write.
+// the write; the unread count is recomputed either way.
 let mirrorStoreOps = Promise.resolve();
 
 function updateMirrorNotifications(mutate) {
   const run = mirrorStoreOps.then(async () => {
     try {
       const data = await chrome.storage.local.get('mirrorNotifications');
-      const next = mutate(data.mirrorNotifications || []);
+      const notifications = data.mirrorNotifications || [];
+      const next = mutate(notifications);
       if (next) {
         await chrome.storage.local.set({ mirrorNotifications: next });
       }
+      await recomputeUnreadMirrorCount(next || notifications);
     } catch (error) {
       console.error('Failed to update mirrorNotifications:', error);
     }
   });
   mirrorStoreOps = run.catch(() => {});
   return run;
+}
+
+// The unread mirror count is derived, not bookkept: the number of entries
+// with activity newer than the last time the popup's notifications tab was
+// opened, excluding dismissed ones. Recomputed inside the queue after every
+// list change, so it cannot drift from the list.
+async function recomputeUnreadMirrorCount(notifications) {
+  const data = await chrome.storage.local.get('lastMirrorReadTime');
+  const lastRead = data.lastMirrorReadTime || 0;
+  const count = notifications.filter(n => !n.dismissed && n.created > lastRead).length;
+  await chrome.storage.local.set({ unreadMirrorCount: count });
+  await updateBadge();
+}
+
+async function markMirrorNotificationsRead() {
+  await chrome.storage.local.set({ lastMirrorReadTime: Date.now() / 1000 });
+  // Queue a no-op mutation so the count recomputes from a consistent snapshot
+  await updateMirrorNotifications(() => null);
 }
 
 async function handleMirrorNotification(mirrorData) {
@@ -1287,11 +1315,6 @@ async function showMirrorNotification(notificationData, isUpdate = false) {
 
   // Play alert sound
   await playAlertSound();
-
-  // Increment unread mirrored notification count. In-place updates count
-  // too: the badge tracks mirror activity since the popup was last opened,
-  // with no per-entry read state.
-  await incrementUnreadMirrorCount();
 }
 
 chrome.notifications.onButtonClicked.addListener(async (notificationId, buttonIndex) => {
@@ -1489,20 +1512,13 @@ async function dismissMirrorNotification(notificationId) {
     if (response.ok) {
       console.log('Mirror notification dismissed successfully');
       // Flag instead of removing: the entry stays in the popup list as
-      // history. Flipping dismissed exactly once (inside the queue) gates
-      // the unread decrement, so the server echo of this dismissal or a
-      // concurrent phone-side dismissal cannot decrement twice.
-      let flipped = false;
+      // history and stops counting toward the unread badge.
       await updateMirrorNotifications((notifications) => {
         const stored = notifications.find(n => n.id === uuid);
         if (!stored || stored.dismissed) return null;
         stored.dismissed = true;
-        flipped = true;
         return notifications;
       });
-      if (flipped) {
-        await decrementUnreadMirrorCount();
-      }
     } else {
       console.error('Failed to dismiss mirror notification:', response.statusText);
     }
@@ -1537,8 +1553,6 @@ async function handleMirrorDismissal(dismissalData) {
       console.log(`Clearing mirror notification for dismissal: ${dismissalData.package_name}`);
       await chrome.notifications.clear(notificationId);
     }
-
-    await decrementUnreadMirrorCount();
   } catch (error) {
     console.error('Error handling mirror dismissal:', error);
   }
@@ -1629,11 +1643,12 @@ async function storeSentMessage(push) {
   await chrome.storage.local.set({ sentMessages: sentMessages.slice(0, 100) });
 }
 
-// Unread count management functions. Both counters are read-modify-write on
-// storage with this service worker as the only writer, so every mutation runs
-// through one queue: overlapping updates (a batch increment against a
-// dismissal decrement or a popup clear) would otherwise read the same starting
-// value and silently drop each other's writes.
+// Unread push count management. The counter is read-modify-write on storage
+// with this service worker as the only writer, so every mutation runs through
+// one queue: overlapping updates (a batch increment against a dismissal
+// decrement or a popup clear) would otherwise read the same starting value
+// and silently drop each other's writes. The mirror count is not managed
+// here; it is derived in recomputeUnreadMirrorCount.
 let unreadCountOps = Promise.resolve();
 
 function updateUnreadCount(storageKey, mutate) {
@@ -1655,24 +1670,12 @@ async function incrementUnreadPushCount(count = 1) {
   return updateUnreadCount('unreadPushCount', current => current + count);
 }
 
-async function incrementUnreadMirrorCount() {
-  return updateUnreadCount('unreadMirrorCount', current => current + 1);
-}
-
 async function decrementUnreadPushCount() {
   return updateUnreadCount('unreadPushCount', current => current - 1);
 }
 
 async function clearUnreadPushCount() {
   return updateUnreadCount('unreadPushCount', () => 0);
-}
-
-async function decrementUnreadMirrorCount() {
-  return updateUnreadCount('unreadMirrorCount', current => current - 1);
-}
-
-async function clearUnreadMirrorCount() {
-  return updateUnreadCount('unreadMirrorCount', () => 0);
 }
 
 async function updateBadge() {
@@ -2200,7 +2203,6 @@ async function clearPushHistory() {
 
 async function clearMirrorHistory() {
   await updateMirrorNotifications(() => []);
-  await clearUnreadMirrorCount();
   console.log('Mirror notification history cleared');
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -635,8 +635,11 @@ async function initializeExtension() {
   // retroactively.
   if (localData.lastMirrorReadTime === undefined) {
     await chrome.storage.local.set({ lastMirrorReadTime: Date.now() / 1000 });
-    await updateMirrorNotifications(() => null);
   }
+
+  // Recompute the derived unread count on startup so the cached value can
+  // never stay stale across service worker restarts.
+  await updateMirrorNotifications(() => null);
 
   if (accessToken) {
     // Initialize encryption if key is stored (userIden should be available from options page)
@@ -1195,7 +1198,7 @@ function updateMirrorNotifications(mutate) {
 async function recomputeUnreadMirrorCount(notifications) {
   const data = await chrome.storage.local.get('lastMirrorReadTime');
   const lastRead = data.lastMirrorReadTime || 0;
-  const count = notifications.filter(n => !n.dismissed && n.created > lastRead).length;
+  const count = notifications.filter(n => !n.dismissed && (n.receivedAt ?? n.created) > lastRead).length;
   await chrome.storage.local.set({ unreadMirrorCount: count });
   await updateBadge();
 }
@@ -1225,6 +1228,11 @@ async function handleMirrorNotification(mirrorData) {
     created: mirrorData.created && typeof mirrorData.created === 'number' && mirrorData.created > 0
       ? mirrorData.created
       : Date.now() / 1000,  // Use current time in seconds if websocket timestamp is invalid
+    // Local-clock arrival stamp. created can be phone/server time, so recency
+    // checks (unread count, popup scroll) use this to stay in one clock
+    // domain with lastMirrorReadTime, and it advances even when an app
+    // re-posts a notification without changing its timestamp.
+    receivedAt: Date.now() / 1000,
     icon: mirrorData.icon,
     title: mirrorData.title,
     body: mirrorData.body,

--- a/src/background.js
+++ b/src/background.js
@@ -1014,6 +1014,39 @@ async function getMirrorIconDataUrl(iconBase64) {
   }
 }
 
+// Android identifies an active notification by the (package_name,
+// notification_tag, notification_id) triple; a repeated mirror of the same
+// triple is a content update of that notification, not a new one.
+function isSameMirrorNotification(a, b) {
+  return a.package_name === b.package_name &&
+    (a.notification_tag ?? null) === (b.notification_tag ?? null) &&
+    a.notification_id === b.notification_id;
+}
+
+// mirrorNotifications is read-modify-write from several concurrent entry
+// points (new mirrors, phone-side dismissals, extension-side dismissals,
+// popup deletes); like unreadCountOps, one queue keeps overlapping mutations
+// from reading the same starting array and dropping each other's writes.
+// mutate() gets the stored array and returns the next one, or falsy to skip
+// the write.
+let mirrorStoreOps = Promise.resolve();
+
+function updateMirrorNotifications(mutate) {
+  const run = mirrorStoreOps.then(async () => {
+    try {
+      const data = await chrome.storage.local.get('mirrorNotifications');
+      const next = mutate(data.mirrorNotifications || []);
+      if (next) {
+        await chrome.storage.local.set({ mirrorNotifications: next });
+      }
+    } catch (error) {
+      console.error('Failed to update mirrorNotifications:', error);
+    }
+  });
+  mirrorStoreOps = run.catch(() => {});
+  return run;
+}
+
 async function handleMirrorNotification(mirrorData) {
   // Check if notification mirroring is enabled
   const configData = await chrome.storage.local.get('notificationMirroring');
@@ -1052,54 +1085,26 @@ async function handleMirrorNotification(mirrorData) {
     }
   }
 
-  // Store in local storage (keep latest 100)
-  const existingNotifications = await chrome.storage.local.get('mirrorNotifications');
-  const notifications = existingNotifications.mirrorNotifications || [];
-
-  const existingIndex = notifications.findIndex(n =>
-    n.package_name === notificationData.package_name &&
-    n.notification_id === notificationData.notification_id
-  );
-
-  if (existingIndex !== -1) {
-    notificationData.id = notifications[existingIndex].id;
-    notifications[existingIndex] = notificationData;
-    await chrome.storage.local.set({ mirrorNotifications: notifications });
-
-    const notifPrefs = await chrome.storage.local.get(['requireInteraction', 'requireInteractionMirrored', 'showOsNotifications']);
-    if (notifPrefs.showOsNotifications !== false) {
-      const appName = notificationData.application_name || notificationData.package_name || getMessage('unknown_app');
-      let message = '';
-      if (notificationData.title) message += `${notificationData.title}\n`;
-      if (notificationData.body) message += `${notificationData.body}`;
-      const notificationOptions = {
-        type: 'basic',
-        title: appName,
-        message: message.trim() || getMessage('new_notification')
-      };
-      const processedIconUrl = await getMirrorIconDataUrl(notificationData.icon);
-      notificationOptions.iconUrl = processedIconUrl || 'assets/icon128.png';
-      if (notificationData.dismissible) {
-        notificationOptions.buttons = [{ title: getMessage('dismiss_button') }];
-      }
-      if (notifPrefs.requireInteraction && notifPrefs.requireInteractionMirrored) {
-        notificationOptions.requireInteraction = true;
-      }
-      chrome.notifications.update(`pushbullet-mirror-${notificationData.id}`, notificationOptions);
+  // Store in local storage (keep latest 100). A repeated mirror of an
+  // existing notification replaces its entry but keeps the stored UUID, so
+  // the Chrome notification and the dismissal flows stay addressable.
+  let isUpdate = false;
+  await updateMirrorNotifications((notifications) => {
+    const existingIndex = notifications.findIndex(n => isSameMirrorNotification(n, notificationData));
+    if (existingIndex !== -1) {
+      notificationData.id = notifications[existingIndex].id;
+      notifications.splice(existingIndex, 1);
+      isUpdate = true;
     }
-    return;
-  }
-
-  notifications.unshift(notificationData);
-  await chrome.storage.local.set({
-    mirrorNotifications: notifications.slice(0, 100)
+    notifications.unshift(notificationData);
+    return notifications.slice(0, 100);
   });
 
-  // Create Chrome notification
-  await showMirrorNotification(notificationData);
+  // Create or replace Chrome notification
+  await showMirrorNotification(notificationData, isUpdate);
 }
 
-async function showMirrorNotification(notificationData) {
+async function showMirrorNotification(notificationData, isUpdate = false) {
   const appName = notificationData.application_name || notificationData.package_name || getMessage('unknown_app');
 
   let message = '';
@@ -1138,14 +1143,23 @@ async function showMirrorNotification(notificationData) {
   // Skip the desktop/OS notification when the master toggle is off (absent
   // means on); the mirrored notification is still recorded and counted as unread.
   if (notifPrefs.showOsNotifications !== false) {
+    if (isUpdate) {
+      // clear() first so the replacement re-alerts; create() alone can
+      // coalesce into a still-visible toast without alerting. update() would
+      // show nothing at all once the old toast is gone.
+      await chrome.notifications.clear(notificationId);
+    }
     chrome.notifications.create(notificationId, notificationOptions);
   }
 
   // Play alert sound
   await playAlertSound();
 
-  // Increment unread mirrored notification count
-  await incrementUnreadMirrorCount();
+  // Increment unread mirrored notification count; a replacement was already
+  // counted when the notification first arrived
+  if (!isUpdate) {
+    await incrementUnreadMirrorCount();
+  }
 }
 
 chrome.notifications.onButtonClicked.addListener(async (notificationId, buttonIndex) => {
@@ -1342,6 +1356,9 @@ async function dismissMirrorNotification(notificationId) {
     
     if (response.ok) {
       console.log('Mirror notification dismissed successfully');
+      // Remove locally right away; the server echoes our own dismissal back
+      // over the websocket and handleMirrorDismissal must find nothing then.
+      await updateMirrorNotifications(notifications => notifications.filter(n => n.id !== uuid));
       // Decrement unread mirror count when successfully dismissed
       await decrementUnreadMirrorCount();
     } else {
@@ -1354,13 +1371,13 @@ async function dismissMirrorNotification(notificationId) {
 
 async function handleMirrorDismissal(dismissalData) {
   try {
-    // Find matching notification in storage by package_name and notification_id
-    const existingNotifications = await chrome.storage.local.get('mirrorNotifications');
-    const notifications = existingNotifications.mirrorNotifications || [];
-    const notification = notifications.find(n =>
-      n.package_name === dismissalData.package_name &&
-      n.notification_id === dismissalData.notification_id
-    );
+    // Find and remove the matching stored notification. Nothing found means
+    // the dismissal was already handled (e.g. the echo of our own dismissal).
+    let notification;
+    await updateMirrorNotifications((notifications) => {
+      notification = notifications.find(n => isSameMirrorNotification(n, dismissalData));
+      return notification ? notifications.filter(n => n.id !== notification.id) : null;
+    });
 
     if (!notification) {
       console.log('No matching notification found for dismissal');
@@ -1376,8 +1393,6 @@ async function handleMirrorDismissal(dismissalData) {
       await chrome.notifications.clear(notificationId);
     }
 
-    const updated = notifications.filter(n => n !== notification);
-    await chrome.storage.local.set({ mirrorNotifications: updated });
     await decrementUnreadMirrorCount();
   } catch (error) {
     console.error('Error handling mirror dismissal:', error);
@@ -2035,31 +2050,16 @@ async function clearPushHistory() {
 }
 
 async function clearMirrorHistory() {
-  try {
-    await chrome.storage.local.set({
-      mirrorNotifications: [],
-      unreadMirrorCount: 0
-    });
-    await updateBadge();
-    console.log('Mirror notification history cleared');
-  } catch (error) {
-    console.error('Failed to clear mirror history:', error);
-  }
+  await updateMirrorNotifications(() => []);
+  await clearUnreadMirrorCount();
+  console.log('Mirror notification history cleared');
 }
 
 async function deleteNotification(id) {
-  try {
-    const data = await chrome.storage.local.get('mirrorNotifications');
-    let notifications = data.mirrorNotifications || [];
-
-    // Filter out the notification with the matching unique ID
-    notifications = notifications.filter(notification => notification.id !== id);
-
-    await chrome.storage.local.set({ mirrorNotifications: notifications });
-    console.log('Notification deleted:', id);
-  } catch (error) {
-    console.error('Failed to delete notification:', error);
-  }
+  // Filter out the notification with the matching unique ID
+  await updateMirrorNotifications(notifications =>
+    notifications.filter(notification => notification.id !== id));
+  console.log('Notification deleted:', id);
 }
 
 async function deletePush(iden) {

--- a/src/background.js
+++ b/src/background.js
@@ -1288,11 +1288,10 @@ async function showMirrorNotification(notificationData, isUpdate = false) {
   // Play alert sound
   await playAlertSound();
 
-  // Increment unread mirrored notification count; a replacement was already
-  // counted when the notification first arrived
-  if (!isUpdate) {
-    await incrementUnreadMirrorCount();
-  }
+  // Increment unread mirrored notification count. In-place updates count
+  // too: the badge tracks mirror activity since the popup was last opened,
+  // with no per-entry read state.
+  await incrementUnreadMirrorCount();
 }
 
 chrome.notifications.onButtonClicked.addListener(async (notificationId, buttonIndex) => {

--- a/src/background.js
+++ b/src/background.js
@@ -1056,6 +1056,40 @@ async function handleMirrorNotification(mirrorData) {
   const existingNotifications = await chrome.storage.local.get('mirrorNotifications');
   const notifications = existingNotifications.mirrorNotifications || [];
 
+  const existingIndex = notifications.findIndex(n =>
+    n.package_name === notificationData.package_name &&
+    n.notification_id === notificationData.notification_id
+  );
+
+  if (existingIndex !== -1) {
+    notificationData.id = notifications[existingIndex].id;
+    notifications[existingIndex] = notificationData;
+    await chrome.storage.local.set({ mirrorNotifications: notifications });
+
+    const notifPrefs = await chrome.storage.local.get(['requireInteraction', 'requireInteractionMirrored', 'showOsNotifications']);
+    if (notifPrefs.showOsNotifications !== false) {
+      const appName = notificationData.application_name || notificationData.package_name || getMessage('unknown_app');
+      let message = '';
+      if (notificationData.title) message += `${notificationData.title}\n`;
+      if (notificationData.body) message += `${notificationData.body}`;
+      const notificationOptions = {
+        type: 'basic',
+        title: appName,
+        message: message.trim() || getMessage('new_notification')
+      };
+      const processedIconUrl = await getMirrorIconDataUrl(notificationData.icon);
+      notificationOptions.iconUrl = processedIconUrl || 'assets/icon128.png';
+      if (notificationData.dismissible) {
+        notificationOptions.buttons = [{ title: getMessage('dismiss_button') }];
+      }
+      if (notifPrefs.requireInteraction && notifPrefs.requireInteractionMirrored) {
+        notificationOptions.requireInteraction = true;
+      }
+      chrome.notifications.update(`pushbullet-mirror-${notificationData.id}`, notificationOptions);
+    }
+    return;
+  }
+
   notifications.unshift(notificationData);
   await chrome.storage.local.set({
     mirrorNotifications: notifications.slice(0, 100)
@@ -1341,6 +1375,10 @@ async function handleMirrorDismissal(dismissalData) {
       console.log(`Clearing mirror notification for dismissal: ${dismissalData.package_name}`);
       await chrome.notifications.clear(notificationId);
     }
+
+    const updated = notifications.filter(n => n !== notification);
+    await chrome.storage.local.set({ mirrorNotifications: updated });
+    await decrementUnreadMirrorCount();
   } catch (error) {
     console.error('Error handling mirror dismissal:', error);
   }

--- a/src/popup.html
+++ b/src/popup.html
@@ -924,6 +924,7 @@
       color: var(--text-secondary);
       overflow-wrap: anywhere;
       line-height: 1.4;
+      white-space: pre-wrap;
     }
 
     .notification-actions {

--- a/src/popup.js
+++ b/src/popup.js
@@ -1318,7 +1318,8 @@ document.addEventListener('DOMContentLoaded', function() {
       const oldFirst = changes.mirrorNotifications.oldValue?.[0];
       const newFirst = changes.mirrorNotifications.newValue?.[0];
       const hasNewContent = newLength >= oldLength && !!newFirst &&
-        (!oldFirst || newFirst.id !== oldFirst.id || newFirst.created !== oldFirst.created);
+        (!oldFirst || newFirst.id !== oldFirst.id ||
+          (newFirst.receivedAt ?? newFirst.created) !== (oldFirst.receivedAt ?? oldFirst.created));
 
       const savedScrollTop = hasNewContent ? null : notificationsList.scrollTop;
       debouncedLoadNotifications(savedScrollTop);

--- a/src/popup.js
+++ b/src/popup.js
@@ -1310,12 +1310,17 @@ document.addEventListener('DOMContentLoaded', function() {
       debouncedLoadMessages(savedScrollTop);
     }
     if (areaName === 'local' && changes.mirrorNotifications) {
-      // Only preserve scroll position when deleting (array shrinks), otherwise scroll to bottom for new notifications
+      // Scroll to bottom only when new content arrived, i.e. a new or updated
+      // entry at the front of the stored array; deletions and dismissed-flag
+      // writes (same entries, same order) keep the scroll position.
       const oldLength = changes.mirrorNotifications.oldValue?.length || 0;
       const newLength = changes.mirrorNotifications.newValue?.length || 0;
-      const isDeleting = newLength < oldLength;
+      const oldFirst = changes.mirrorNotifications.oldValue?.[0];
+      const newFirst = changes.mirrorNotifications.newValue?.[0];
+      const hasNewContent = newLength >= oldLength && !!newFirst &&
+        (!oldFirst || newFirst.id !== oldFirst.id || newFirst.created !== oldFirst.created);
 
-      const savedScrollTop = isDeleting ? notificationsList.scrollTop : null;
+      const savedScrollTop = hasNewContent ? null : notificationsList.scrollTop;
       debouncedLoadNotifications(savedScrollTop);
     }
     if (areaName === 'sync' && changes.accessToken) {


### PR DESCRIPTION
Original:

> Fix to prevent constant new notifications not being refreshedcorrectly:
> 
> - Current behaviour is that with each change of song in a music app or with each new message a new notification will appear but will not dispose of the old one. Additionally temporary notifications like "WhatsApp Checking for new messages" will stay persistent.
> - This behaviour can result in huge numbers of repeated notifications in a short timespan and does not match the old extension behaviour.
> - The fix is two-fold:
> - First is to filter out dismissed notifications from the list
> - Second is to check for existing entries and replace if the id matches.
> 
> And separately, a small fix to the CSS to put each new message (from WhatsApp etc) onto a new line within the same notification. Previously it would append them on the same line

Repeated mirrors of the same Android notification (song changes, chat updates, transient status notifications) previously stacked as new entries and new toasts, and phone-side dismissals only cleared the toast, leaving stale entries and a stale badge.

- Match incoming mirrors by the Android identity triple (package_name, notification_tag, notification_id). A repeat of a live notification replaces its stored entry in place, reusing the stored UUID so the Chrome notification and dismissal flows stay addressable.
- Replace the toast with clear + create so an updated notification still alerts after the old toast was closed.
- Dismissals (phone-side and extension-side) mark the entry dismissed instead of removing it: the popup list is a history, managed by the existing per-item delete and clear-all buttons. A later notification on the same Android slot becomes a new entry.
- The unread badge is derived from the list: the number of non-dismissed entries with activity newer than the last time the popup was opened, recomputed inside a serialized write queue after every change. It always matches what the popup shows, opening the popup is guaranteed to clear it, and recency uses a local arrival stamp so phone or server clock skew cannot affect it.
- All mirrorNotifications storage writes are serialized through one queue so concurrent handlers cannot drop each other's writes.
- Popup: notification bodies preserve line breaks (white-space: pre-wrap); the list keeps scroll position on dismissals and deletions and scrolls to bottom only for new content.

