### PR TITLE
Add option to Disable Context Menu

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -92,6 +92,9 @@
   "show_per_send_target_label": {
     "message": "Show per-send target picker in popup"
   },
+  "enable_context_menu_label": {
+    "message": "Enable right-click context menu"
+  },
   "all_devices": {
     "message": "All devices"
   },

--- a/src/background.js
+++ b/src/background.js
@@ -426,7 +426,7 @@ async function seedEnableChatDefault() {
 }
 
 chrome.storage.onChanged.addListener(async (changes, namespace) => {
-  if (namespace === 'local' && (changes.devices || changes.people)) {
+  if (namespace === 'local' && (changes.devices || changes.people || changes.enableContextMenu)) {
     await setupContextMenus();
   }
   if (namespace === 'local' && changes.people) {
@@ -2236,8 +2236,16 @@ async function setupContextMenus() {
       // an update doesn't read local before the lists land (the concurrency
       // guard above drops the rebuild the migration would otherwise trigger)
       await devicesPeopleMigration;
-      // Get stored devices and people data
-      const data = await chrome.storage.local.get(['devices', 'people']);
+      // Get stored devices, people & enableContextMenu data
+      const data = await chrome.storage.local.get(['devices', 'people', 'enableContextMenu']);
+
+      // Don't create context menu if option is manually disabled (default is true or not set)
+      if (data.enableContextMenu === false) {
+        isSettingUpContextMenus = false;
+        
+        return resolve();
+      }
+
       const devices = data.devices || [];
       const people = data.people || [];
     

--- a/src/options.html
+++ b/src/options.html
@@ -958,6 +958,13 @@
           <div class="toggle-slider"></div>
         </div>
       </div>
+      <div class="toggle-container">
+        <label class="toggle-label" data-i18n="enable_context_menu_label">Enable right-click context menu</label>
+        <input type="checkbox" id="enableContextMenu" class="toggle-input">
+        <div class="toggle-switch" id="enableContextMenuToggle">
+          <div class="toggle-slider"></div>
+        </div>
+      </div>
       <div class="form-group">
         <label data-i18n="language_label">Language:</label>
         <div id="languageList" class="device-list"></div>

--- a/src/options.js
+++ b/src/options.js
@@ -78,6 +78,8 @@ document.addEventListener('DOMContentLoaded', async function() {
   const otherDeviceListGroup = document.getElementById('otherDeviceListGroup');
   const showPerSendTargetCheckbox = document.getElementById('showPerSendTarget');
   const showPerSendTargetToggle = document.getElementById('showPerSendTargetToggle');
+  const enableContextMenuCheckbox = document.getElementById('enableContextMenu');
+  const enableContextMenuToggle = document.getElementById('enableContextMenuToggle');
 
   // Tab elements
   const tabs = document.querySelectorAll('.tab');
@@ -609,7 +611,7 @@ document.addEventListener('DOMContentLoaded', async function() {
     chrome.storage.sync.get(['accessToken', 'userIden'], resolve);
   });
   const localData = await new Promise(resolve => {
-    chrome.storage.local.get(['devices', 'people', 'remoteDeviceId', 'showPerSendTarget', 'autoOpenLinks', 'autoOpenFiles', 'autoOpenOnResume', 'hideNotificationOnAutoOpen', 'autoOpenLinksFromPeople', 'autoOpenTrustedPeople', 'enableChat', 'notificationMirroring', 'onlyBrowserPushes', 'showOtherDevicePushes', 'showNoTargetPushes', 'showPeoplePushes', 'hideBrowserPushes', 'showSmsShortcut', 'showQuickShare', 'requireInteraction', 'requireInteractionPushes', 'requireInteractionMirrored', 'closeAsDismiss', 'displayUnreadCounts', 'displayUnreadPushes', 'displayUnreadMirrored', 'displayUnreadChats', 'colorMode', 'languageMode', 'defaultTab', 'playSoundOnNotification', 'showOsNotifications', 'selectedOtherDeviceIds'], resolve);
+    chrome.storage.local.get(['devices', 'people', 'remoteDeviceId', 'showPerSendTarget', 'enableContextMenu', 'autoOpenLinks', 'autoOpenFiles', 'autoOpenOnResume', 'hideNotificationOnAutoOpen', 'autoOpenLinksFromPeople', 'autoOpenTrustedPeople', 'enableChat', 'notificationMirroring', 'onlyBrowserPushes', 'showOtherDevicePushes', 'showNoTargetPushes', 'showPeoplePushes', 'hideBrowserPushes', 'showSmsShortcut', 'showQuickShare', 'requireInteraction', 'requireInteractionPushes', 'requireInteractionMirrored', 'closeAsDismiss', 'displayUnreadCounts', 'displayUnreadPushes', 'displayUnreadMirrored', 'displayUnreadChats', 'colorMode', 'languageMode', 'defaultTab', 'playSoundOnNotification', 'showOsNotifications', 'selectedOtherDeviceIds'], resolve);
   });
   const data = { ...syncData, ...localData };
   
@@ -792,6 +794,10 @@ document.addEventListener('DOMContentLoaded', async function() {
     showOsNotificationsCheckbox.checked = data.showOsNotifications !== false; // Default to true
     updateShowOsNotificationsToggleVisual();
     updateShowOsNotificationsVisibility();
+
+    // Load context menu setting (default is true/on)
+    enableContextMenuCheckbox.checked = data.enableContextMenu !== false; // Default to true
+    updateEnableContextMenuToggleVisual();
     
     // Update conditional visibility for default tab option
     updateDefaultTabVisibility();
@@ -1036,6 +1042,11 @@ document.addEventListener('DOMContentLoaded', async function() {
     showOsNotificationsCheckbox.checked = !showOsNotificationsCheckbox.checked;
     updateShowOsNotificationsToggleVisual();
     updateShowOsNotificationsVisibility();
+  });
+
+  enableContextMenuToggle.addEventListener('click', function() {
+    enableContextMenuCheckbox.checked = !enableContextMenuCheckbox.checked;
+    updateEnableContextMenuToggleVisual();
   });
 
   // Resolve the account iden behind an access token via /v2/users/me. The
@@ -1434,7 +1445,8 @@ document.addEventListener('DOMContentLoaded', async function() {
       colorMode: colorModeDropdown.getValue(),
       defaultTab: defaultTabDropdown.getValue(),
       playSoundOnNotification: playSoundOnNotificationCheckbox.checked,
-      showOsNotifications: showOsNotificationsCheckbox.checked
+      showOsNotifications: showOsNotificationsCheckbox.checked,
+      enableContextMenu: enableContextMenuCheckbox.checked
     };
     
     // Handle encryption password - derive key and store locally
@@ -1512,7 +1524,8 @@ document.addEventListener('DOMContentLoaded', async function() {
       colorMode: saveData.colorMode,
       defaultTab: saveData.defaultTab,
       playSoundOnNotification: saveData.playSoundOnNotification,
-      showOsNotifications: saveData.showOsNotifications
+      showOsNotifications: saveData.showOsNotifications,
+      enableContextMenu: saveData.enableContextMenu
     };
     
     // Save to both storages
@@ -1712,6 +1725,14 @@ document.addEventListener('DOMContentLoaded', async function() {
       showPerSendTargetToggle.classList.add('active');
     } else {
       showPerSendTargetToggle.classList.remove('active');
+    }
+  }
+
+  function updateEnableContextMenuToggleVisual() {
+    if (enableContextMenuCheckbox.checked) {
+      enableContextMenuToggle.classList.add('active');
+    } else {
+      enableContextMenuToggle.classList.remove('active');
     }
   }
 


### PR DESCRIPTION
This PR introduces a new user preference to enable or disable the extension's context menu (right-click) item. 

Currently, the context menu is hardcoded to appear for all users. For users who primarily use the browser toolbar icon or keyboard shortcuts, the context menu item can clutter their native browser experience. This change gives them the flexibility to toggle it off while defaulting to `true` so existing users experience no disruption.

## What changed
* **UI:** Added a new checkbox in `options.html` / `options.js` to toggle the context menu.
* **State Management:** The preference (`enableContextMenu`) is saved to `chrome.storage.local`.
* **Background Logic:** Added an early return in the existing `setupContextMenus()` function in `background.js`. If the `enableContextMenu` flag evaluates to false, it aborts and skips creating the menu item.
* **i18n:** Added the `enable_context_menu_label` key to `_locales/en/messages.json`.

## Screenshots
<img alt="image" src="https://github.com/user-attachments/assets/8ef4a25f-a960-48f2-a150-626d4fbd2059" />