### PR TITLE
Show Channel/RSS pushes based on new toggle option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Require a [Pushbullet](https://www.pushbullet.com/) account. Features include:
 
 - Receive and send pushes
 - Filter to show and notify pushes by target device
+- Optionally include pushes from Channel and RSS feed subscriptions, labelled with the feed's name
 - Push files/images by pasting, dragging, or uploading
 - Push current page's URL, selected text, or images from context menu
 - Push via keyboard shortcut

--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "الإرسالات إلى «جميع الأجهزة» (بدون جهاز مستهدف)"
   },
-  "channel_pushes_label": {
-    "message": "تضمين إرسالات القنوات/RSS"
-  },
   "delete_notification": {
     "message": "حذف الإشعار"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "ينطبق على كل من قائمة الإرسالات في النافذة المنبثقة والإشعارات."
+  },
+  "channel_pushes_label": {
+    "message": "الإرسالات من القنوات التي تتابعها (غير المكتومة)"
+  },
+  "channel_label": {
+    "message": "قناة"
   }
 }

--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "الإرسالات إلى «جميع الأجهزة» (بدون جهاز مستهدف)"
   },
+  "channel_pushes_label": {
+    "message": "تضمين إرسالات القنوات/RSS"
+  },
   "delete_notification": {
     "message": "حذف الإشعار"
   },

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Изпратени до „Всички устройства“ (без цел)"
   },
+  "channel_pushes_label": {
+    "message": "Включване на изпращания от канали/RSS"
+  },
   "delete_notification": {
     "message": "Изтрий известието"
   },

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Изпратени до „Всички устройства“ (без цел)"
   },
-  "channel_pushes_label": {
-    "message": "Включване на изпращания от канали/RSS"
-  },
   "delete_notification": {
     "message": "Изтрий известието"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Важи както за списъка в изскачащия прозорец, така и за известията."
+  },
+  "channel_pushes_label": {
+    "message": "От каналите, които следвате (незаглушени)"
+  },
+  "channel_label": {
+    "message": "Канал"
   }
 }

--- a/src/_locales/ca/messages.json
+++ b/src/_locales/ca/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Enviats a «Tots els dispositius» (sense destinatari)"
   },
-  "channel_pushes_label": {
-    "message": "Inclou enviaments de canals/RSS"
-  },
   "delete_notification": {
     "message": "Eliminar notificació"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "S'aplica tant a la llista de la finestra emergent com a les notificacions."
+  },
+  "channel_pushes_label": {
+    "message": "Des dels canals que segueixes (no silenciats)"
+  },
+  "channel_label": {
+    "message": "Canal"
   }
 }

--- a/src/_locales/ca/messages.json
+++ b/src/_locales/ca/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Enviats a «Tots els dispositius» (sense destinatari)"
   },
+  "channel_pushes_label": {
+    "message": "Inclou enviaments de canals/RSS"
+  },
   "delete_notification": {
     "message": "Eliminar notificació"
   },

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Odesláno na „Všechna zařízení“ (bez cíle)"
   },
+  "channel_pushes_label": {
+    "message": "Zahrnout push z kanálů/RSS"
+  },
   "delete_notification": {
     "message": "Smazat oznámení"
   },

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Odesláno na „Všechna zařízení“ (bez cíle)"
   },
-  "channel_pushes_label": {
-    "message": "Zahrnout push z kanálů/RSS"
-  },
   "delete_notification": {
     "message": "Smazat oznámení"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Platí pro seznam v popup i pro oznámení."
+  },
+  "channel_pushes_label": {
+    "message": "Ze sledovaných kanálů (neztlumené)"
+  },
+  "channel_label": {
+    "message": "Kanál"
   }
 }

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Sendt til »Alle enheder« (uden målenhed)"
   },
+  "channel_pushes_label": {
+    "message": "Inkludér pushes fra kanaler/RSS"
+  },
   "delete_notification": {
     "message": "Slet notifikation"
   },

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Sendt til »Alle enheder« (uden målenhed)"
   },
-  "channel_pushes_label": {
-    "message": "Inkludér pushes fra kanaler/RSS"
-  },
   "delete_notification": {
     "message": "Slet notifikation"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Gælder for både popup-listen og notifikationer."
+  },
+  "channel_pushes_label": {
+    "message": "Fra kanaler du følger (ikke lydløse)"
+  },
+  "channel_label": {
+    "message": "Kanal"
   }
 }

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Gesendet an „Alle Geräte“ (kein Zielgerät)"
   },
-  "channel_pushes_label": {
-    "message": "Kanal-/RSS-Pushes einbeziehen"
-  },
   "delete_notification": {
     "message": "Benachrichtigung löschen"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Gilt sowohl für die Liste im Popup als auch für Benachrichtigungen."
+  },
+  "channel_pushes_label": {
+    "message": "Von gefolgten Kanälen (nicht stummgeschaltet)"
+  },
+  "channel_label": {
+    "message": "Kanal"
   }
 }

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Gesendet an „Alle Geräte“ (kein Zielgerät)"
   },
+  "channel_pushes_label": {
+    "message": "Kanal-/RSS-Pushes einbeziehen"
+  },
   "delete_notification": {
     "message": "Benachrichtigung löschen"
   },

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Σταλμένες σε «Όλες οι συσκευές» (χωρίς στόχο)"
   },
+  "channel_pushes_label": {
+    "message": "Συμπερίληψη αποστολών από κανάλια/RSS"
+  },
   "delete_notification": {
     "message": "Διαγραφή ειδοποίησης"
   },

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Σταλμένες σε «Όλες οι συσκευές» (χωρίς στόχο)"
   },
-  "channel_pushes_label": {
-    "message": "Συμπερίληψη αποστολών από κανάλια/RSS"
-  },
   "delete_notification": {
     "message": "Διαγραφή ειδοποίησης"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Ισχύει τόσο για τη λίστα στο popup όσο και για τις ειδοποιήσεις."
+  },
+  "channel_pushes_label": {
+    "message": "Από κανάλια που ακολουθείτε (χωρίς σίγαση)"
+  },
+  "channel_label": {
+    "message": "Κανάλι"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -362,6 +362,9 @@
   "pushes_without_target_label": {
     "message": "Sent to \"All devices\" (no target)"
   },
+  "channel_pushes_label": {
+    "message": "Include Channel/RSS pushes"
+  },
   "delete_notification": {
     "message": "Delete notification"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -363,7 +363,10 @@
     "message": "Sent to \"All devices\" (no target)"
   },
   "channel_pushes_label": {
-    "message": "Include Channel/RSS pushes"
+    "message": "From channels you follow (unmuted)"
+  },
+  "channel_label": {
+    "message": "Channel"
   },
   "delete_notification": {
     "message": "Delete notification"

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Enviados a «Todos los dispositivos» (sin destino)"
   },
-  "channel_pushes_label": {
-    "message": "Incluir envíos de canales/RSS"
-  },
   "delete_notification": {
     "message": "Eliminar notificación"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Se aplica tanto a la lista del popup como a las notificaciones."
+  },
+  "channel_pushes_label": {
+    "message": "De los canales que sigues (sin silenciar)"
+  },
+  "channel_label": {
+    "message": "Canal"
   }
 }

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Enviados a «Todos los dispositivos» (sin destino)"
   },
+  "channel_pushes_label": {
+    "message": "Incluir envíos de canales/RSS"
+  },
   "delete_notification": {
     "message": "Eliminar notificación"
   },

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Lähetetty kohteeseen ”Kaikki laitteet” (ei kohdetta)"
   },
+  "channel_pushes_label": {
+    "message": "Sisällytä kanava-/RSS-pushit"
+  },
   "delete_notification": {
     "message": "Poista ilmoitus"
   },

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Lähetetty kohteeseen ”Kaikki laitteet” (ei kohdetta)"
   },
-  "channel_pushes_label": {
-    "message": "Sisällytä kanava-/RSS-pushit"
-  },
   "delete_notification": {
     "message": "Poista ilmoitus"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Koskee sekä ponnahdusikkunan listaa että ilmoituksia."
+  },
+  "channel_pushes_label": {
+    "message": "Seuraamiltasi kanavilta (ei mykistetyt)"
+  },
+  "channel_label": {
+    "message": "Kanava"
   }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Envoyés vers « Tous les appareils » (sans cible)"
   },
+  "channel_pushes_label": {
+    "message": "Inclure les pushs de chaînes/RSS"
+  },
   "delete_notification": {
     "message": "Supprimer la notification"
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Envoyés vers « Tous les appareils » (sans cible)"
   },
-  "channel_pushes_label": {
-    "message": "Inclure les pushs de chaînes/RSS"
-  },
   "delete_notification": {
     "message": "Supprimer la notification"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "S'applique à la fois à la liste de la popup et aux notifications."
+  },
+  "channel_pushes_label": {
+    "message": "Des canaux que vous suivez (non muets)"
+  },
+  "channel_label": {
+    "message": "Canal"
   }
 }

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "דחיפות שנשלחו אל \"כל המכשירים\" (ללא יעד)"
   },
+  "channel_pushes_label": {
+    "message": "כלול דחיפות מערוצים/RSS"
+  },
   "delete_notification": {
     "message": "מחק התראה"
   },

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "דחיפות שנשלחו אל \"כל המכשירים\" (ללא יעד)"
   },
-  "channel_pushes_label": {
-    "message": "כלול דחיפות מערוצים/RSS"
-  },
   "delete_notification": {
     "message": "מחק התראה"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "חל גם על הרשימה בחלונית הקופצת וגם על ההתראות."
+  },
+  "channel_pushes_label": {
+    "message": "דחיפות מערוצים שבמעקב (לא מושתקים)"
+  },
+  "channel_label": {
+    "message": "ערוץ"
   }
 }

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "„Minden eszköz”-re küldött (céleszköz nélkül)"
   },
+  "channel_pushes_label": {
+    "message": "Csatorna-/RSS-küldések is"
+  },
   "delete_notification": {
     "message": "Értesítés törlése"
   },

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "„Minden eszköz”-re küldött (céleszköz nélkül)"
   },
-  "channel_pushes_label": {
-    "message": "Csatorna-/RSS-küldések is"
-  },
   "delete_notification": {
     "message": "Értesítés törlése"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "A felugró ablak listájára és az értesítésekre is vonatkozik."
+  },
+  "channel_pushes_label": {
+    "message": "Követett csatornákról (nem némítva)"
+  },
+  "channel_label": {
+    "message": "Csatorna"
   }
 }

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Dikirim ke “Semua perangkat” (tanpa target)"
   },
+  "channel_pushes_label": {
+    "message": "Sertakan push saluran/RSS"
+  },
   "delete_notification": {
     "message": "Hapus notifikasi"
   },

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Dikirim ke “Semua perangkat” (tanpa target)"
   },
-  "channel_pushes_label": {
-    "message": "Sertakan push saluran/RSS"
-  },
   "delete_notification": {
     "message": "Hapus notifikasi"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Berlaku untuk daftar di popup maupun notifikasi."
+  },
+  "channel_pushes_label": {
+    "message": "Dari saluran yang Anda ikuti (tidak dibisukan)"
+  },
+  "channel_label": {
+    "message": "Saluran"
   }
 }

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "inviati a «Tutti i dispositivi» (nessuna destinazione)"
   },
-  "channel_pushes_label": {
-    "message": "Includi i push di canali/RSS"
-  },
   "delete_notification": {
     "message": "Elimina notifica"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Si applica sia all'elenco del popup che alle notifiche."
+  },
+  "channel_pushes_label": {
+    "message": "Dai canali che segui (non silenziati)"
+  },
+  "channel_label": {
+    "message": "Canale"
   }
 }

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "inviati a «Tutti i dispositivi» (nessuna destinazione)"
   },
+  "channel_pushes_label": {
+    "message": "Includi i push di canali/RSS"
+  },
   "delete_notification": {
     "message": "Elimina notifica"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "「すべてのデバイス」へのプッシュ（ターゲットなし）"
   },
+  "channel_pushes_label": {
+    "message": "チャンネル/RSS のプッシュを含める"
+  },
   "delete_notification": {
     "message": "通知を削除"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "「すべてのデバイス」へのプッシュ（ターゲットなし）"
   },
-  "channel_pushes_label": {
-    "message": "チャンネル/RSS のプッシュを含める"
-  },
   "delete_notification": {
     "message": "通知を削除"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "ポップアップの一覧と通知の両方に適用されます。"
+  },
+  "channel_pushes_label": {
+    "message": "フォロー中のチャンネルからのプッシュ（ミュートを除く）"
+  },
+  "channel_label": {
+    "message": "チャンネル"
   }
 }

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "“모든 기기”로 보낸 푸시 (대상 없음)"
   },
-  "channel_pushes_label": {
-    "message": "채널/RSS 푸시 포함"
-  },
   "delete_notification": {
     "message": "알림 삭제"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "팝업 목록과 알림 모두에 적용됩니다."
+  },
+  "channel_pushes_label": {
+    "message": "팔로우하는 채널에서 온 푸시 (음소거 제외)"
+  },
+  "channel_label": {
+    "message": "채널"
   }
 }

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "“모든 기기”로 보낸 푸시 (대상 없음)"
   },
+  "channel_pushes_label": {
+    "message": "채널/RSS 푸시 포함"
+  },
   "delete_notification": {
     "message": "알림 삭제"
   },

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Verzonden naar \"Alle apparaten\" (geen doel)"
   },
+  "channel_pushes_label": {
+    "message": "Pushes van kanalen/RSS opnemen"
+  },
   "delete_notification": {
     "message": "Melding verwijderen"
   },

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Verzonden naar \"Alle apparaten\" (geen doel)"
   },
-  "channel_pushes_label": {
-    "message": "Pushes van kanalen/RSS opnemen"
-  },
   "delete_notification": {
     "message": "Melding verwijderen"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Geldt voor zowel de lijst in de popup als meldingen."
+  },
+  "channel_pushes_label": {
+    "message": "Van kanalen die je volgt (niet gedempt)"
+  },
+  "channel_label": {
+    "message": "Kanaal"
   }
 }

--- a/src/_locales/no/messages.json
+++ b/src/_locales/no/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Sendt til «Alle enheter» (uten mål)"
   },
+  "channel_pushes_label": {
+    "message": "Inkluder pushes fra kanaler/RSS"
+  },
   "delete_notification": {
     "message": "Slett varsel"
   },

--- a/src/_locales/no/messages.json
+++ b/src/_locales/no/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Sendt til «Alle enheter» (uten mål)"
   },
-  "channel_pushes_label": {
-    "message": "Inkluder pushes fra kanaler/RSS"
-  },
   "delete_notification": {
     "message": "Slett varsel"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Gjelder både push-listen i popup og varslene."
+  },
+  "channel_pushes_label": {
+    "message": "Fra kanaler du følger (ikke dempede)"
+  },
+  "channel_label": {
+    "message": "Kanal"
   }
 }

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Wysłane do „Wszystkich urządzeń” (bez celu)"
   },
+  "channel_pushes_label": {
+    "message": "Uwzględnij push z kanałów/RSS"
+  },
   "delete_notification": {
     "message": "Usuń powiadomienie"
   },

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Wysłane do „Wszystkich urządzeń” (bez celu)"
   },
-  "channel_pushes_label": {
-    "message": "Uwzględnij push z kanałów/RSS"
-  },
   "delete_notification": {
     "message": "Usuń powiadomienie"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Dotyczy zarówno listy w oknie popup, jak i powiadomień."
+  },
+  "channel_pushes_label": {
+    "message": "Z kanałów, które obserwujesz (nie wyciszone)"
+  },
+  "channel_label": {
+    "message": "Kanał"
   }
 }

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Enviados para “Todos os dispositivos” (sem destino)"
   },
-  "channel_pushes_label": {
-    "message": "Incluir pushs de canais/RSS"
-  },
   "delete_notification": {
     "message": "Excluir notificação"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Aplica-se tanto à lista no popup quanto às notificações."
+  },
+  "channel_pushes_label": {
+    "message": "Dos canais que você segue (não silenciados)"
+  },
+  "channel_label": {
+    "message": "Canal"
   }
 }

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Enviados para “Todos os dispositivos” (sem destino)"
   },
+  "channel_pushes_label": {
+    "message": "Incluir pushs de canais/RSS"
+  },
   "delete_notification": {
     "message": "Excluir notificação"
   },

--- a/src/_locales/pt_PT/messages.json
+++ b/src/_locales/pt_PT/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Enviados para «Todos os dispositivos» (sem destino)"
   },
+  "channel_pushes_label": {
+    "message": "Incluir pushs de canais/RSS"
+  },
   "delete_notification": {
     "message": "Eliminar notificação"
   },

--- a/src/_locales/pt_PT/messages.json
+++ b/src/_locales/pt_PT/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Enviados para «Todos os dispositivos» (sem destino)"
   },
-  "channel_pushes_label": {
-    "message": "Incluir pushs de canais/RSS"
-  },
   "delete_notification": {
     "message": "Eliminar notificação"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Aplica-se à lista do popup e às notificações."
+  },
+  "channel_pushes_label": {
+    "message": "Dos canais que segue (não silenciados)"
+  },
+  "channel_label": {
+    "message": "Canal"
   }
 }

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Trimise către „Toate dispozitivele” (fără țintă)"
   },
-  "channel_pushes_label": {
-    "message": "Include push-uri de la canale/RSS"
-  },
   "delete_notification": {
     "message": "Șterge notificarea"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Se aplică atât listei de push-uri din popup, cât și notificărilor."
+  },
+  "channel_pushes_label": {
+    "message": "Din canalele urmărite (cu sunet)"
+  },
+  "channel_label": {
+    "message": "Canal"
   }
 }

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Trimise către „Toate dispozitivele” (fără țintă)"
   },
+  "channel_pushes_label": {
+    "message": "Include push-uri de la canale/RSS"
+  },
   "delete_notification": {
     "message": "Șterge notificarea"
   },

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Push на «Все устройства» (без получателя)"
   },
-  "channel_pushes_label": {
-    "message": "Включать push из каналов/RSS"
-  },
   "delete_notification": {
     "message": "Удалить уведомление"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Распространяется как на список всплывающего окна, так и на уведомления."
+  },
+  "channel_pushes_label": {
+    "message": "Из каналов, на которые вы подписаны (со звуком)"
+  },
+  "channel_label": {
+    "message": "Канал"
   }
 }

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Push на «Все устройства» (без получателя)"
   },
+  "channel_pushes_label": {
+    "message": "Включать push из каналов/RSS"
+  },
   "delete_notification": {
     "message": "Удалить уведомление"
   },

--- a/src/_locales/sk/messages.json
+++ b/src/_locales/sk/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Odoslané na „Všetky zariadenia“ (bez cieľa)"
   },
-  "channel_pushes_label": {
-    "message": "Zahrnúť push z kanálov/RSS"
-  },
   "delete_notification": {
     "message": "Odstrániť upozornenie"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Platí pre zoznam v popup-e aj pre oznámenia."
+  },
+  "channel_pushes_label": {
+    "message": "Zo sledovaných kanálov (nestlmené)"
+  },
+  "channel_label": {
+    "message": "Kanál"
   }
 }

--- a/src/_locales/sk/messages.json
+++ b/src/_locales/sk/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Odoslané na „Všetky zariadenia“ (bez cieľa)"
   },
+  "channel_pushes_label": {
+    "message": "Zahrnúť push z kanálov/RSS"
+  },
   "delete_notification": {
     "message": "Odstrániť upozornenie"
   },

--- a/src/_locales/sl/messages.json
+++ b/src/_locales/sl/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Poslano na »Vse naprave« (brez cilja)"
   },
-  "channel_pushes_label": {
-    "message": "Vključi pushes s kanalov/RSS"
-  },
   "delete_notification": {
     "message": "Izbriši obvestilo"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Velja tako za seznam v pojavnem oknu kot za obvestila."
+  },
+  "channel_pushes_label": {
+    "message": "Iz sledenih kanalov (brez utišanja)"
+  },
+  "channel_label": {
+    "message": "Kanal"
   }
 }

--- a/src/_locales/sl/messages.json
+++ b/src/_locales/sl/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Poslano na »Vse naprave« (brez cilja)"
   },
+  "channel_pushes_label": {
+    "message": "Vključi pushes s kanalov/RSS"
+  },
   "delete_notification": {
     "message": "Izbriši obvestilo"
   },

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Skickade till ”Alla enheter” (utan mål)"
   },
-  "channel_pushes_label": {
-    "message": "Inkludera pushes från kanaler/RSS"
-  },
   "delete_notification": {
     "message": "Ta bort avisering"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Gäller både listan i popup-fönstret och aviseringarna."
+  },
+  "channel_pushes_label": {
+    "message": "Från följda kanaler (inte tystade)"
+  },
+  "channel_label": {
+    "message": "Kanal"
   }
 }

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Skickade till ”Alla enheter” (utan mål)"
   },
+  "channel_pushes_label": {
+    "message": "Inkludera pushes från kanaler/RSS"
+  },
   "delete_notification": {
     "message": "Ta bort avisering"
   },

--- a/src/_locales/th/messages.json
+++ b/src/_locales/th/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "ส่งไปยัง “ทุกเครื่อง” (ไม่มีเป้าหมาย)"
   },
+  "channel_pushes_label": {
+    "message": "รวมพุชจากช่อง/RSS"
+  },
   "delete_notification": {
     "message": "ลบการแจ้งเตือน"
   },

--- a/src/_locales/th/messages.json
+++ b/src/_locales/th/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "ส่งไปยัง “ทุกเครื่อง” (ไม่มีเป้าหมาย)"
   },
-  "channel_pushes_label": {
-    "message": "รวมพุชจากช่อง/RSS"
-  },
   "delete_notification": {
     "message": "ลบการแจ้งเตือน"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "มีผลกับทั้งรายการในป๊อปอัพและการแจ้งเตือน"
+  },
+  "channel_pushes_label": {
+    "message": "จากช่องที่ติดตาม (เปิดเสียง)"
+  },
+  "channel_label": {
+    "message": "ช่อง"
   }
 }

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "“Tüm cihazlar”a gönderilen push'lar (hedefsiz)"
   },
-  "channel_pushes_label": {
-    "message": "Kanal/RSS push'larını dahil et"
-  },
   "delete_notification": {
     "message": "Bildirimi sil"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Hem popup'taki liste hem de bildirimler için geçerlidir."
+  },
+  "channel_pushes_label": {
+    "message": "Takip edilen kanallardan (sesi açık)"
+  },
+  "channel_label": {
+    "message": "Kanal"
   }
 }

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "“Tüm cihazlar”a gönderilen push'lar (hedefsiz)"
   },
+  "channel_pushes_label": {
+    "message": "Kanal/RSS push'larını dahil et"
+  },
   "delete_notification": {
     "message": "Bildirimi sil"
   },

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Push надіслані на «Усі пристрої» (без цілі)"
   },
-  "channel_pushes_label": {
-    "message": "Включати push з каналів/RSS"
-  },
   "delete_notification": {
     "message": "Видалити сповіщення"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Стосується як списку у спливаючому вікні, так і сповіщень."
+  },
+  "channel_pushes_label": {
+    "message": "Push із каналів, на які ви підписані (зі звуком)"
+  },
+  "channel_label": {
+    "message": "Канал"
   }
 }

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Push надіслані на «Усі пристрої» (без цілі)"
   },
+  "channel_pushes_label": {
+    "message": "Включати push з каналів/RSS"
+  },
   "delete_notification": {
     "message": "Видалити сповіщення"
   },

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "Đã gửi tới “Tất cả thiết bị” (không có đích)"
   },
+  "channel_pushes_label": {
+    "message": "Bao gồm push từ kênh/RSS"
+  },
   "delete_notification": {
     "message": "Xóa thông báo"
   },

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "Đã gửi tới “Tất cả thiết bị” (không có đích)"
   },
-  "channel_pushes_label": {
-    "message": "Bao gồm push từ kênh/RSS"
-  },
   "delete_notification": {
     "message": "Xóa thông báo"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "Áp dụng cho cả danh sách push trong popup và thông báo."
+  },
+  "channel_pushes_label": {
+    "message": "Từ kênh đã theo dõi (đã bật tiếng)"
+  },
+  "channel_label": {
+    "message": "Kênh"
   }
 }

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "发送到“所有设备”的推送（无目标）"
   },
+  "channel_pushes_label": {
+    "message": "包含频道/RSS 推送"
+  },
   "delete_notification": {
     "message": "删除通知"
   },

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "发送到“所有设备”的推送（无目标）"
   },
-  "channel_pushes_label": {
-    "message": "包含频道/RSS 推送"
-  },
   "delete_notification": {
     "message": "删除通知"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "同时适用于弹窗列表和通知。"
+  },
+  "channel_pushes_label": {
+    "message": "来自已关注频道的推送（未静音）"
+  },
+  "channel_label": {
+    "message": "频道"
   }
 }

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -299,6 +299,9 @@
   "pushes_without_target_label": {
     "message": "傳送到「所有裝置」（無目標）的推送"
   },
+  "channel_pushes_label": {
+    "message": "包含頻道/RSS 推送"
+  },
   "delete_notification": {
     "message": "刪除通知"
   },

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -299,9 +299,6 @@
   "pushes_without_target_label": {
     "message": "傳送到「所有裝置」（無目標）的推送"
   },
-  "channel_pushes_label": {
-    "message": "包含頻道/RSS 推送"
-  },
   "delete_notification": {
     "message": "刪除通知"
   },
@@ -430,5 +427,11 @@
   },
   "show_pushes_tip": {
     "message": "同時適用於彈出視窗中的清單和通知。"
+  },
+  "channel_pushes_label": {
+    "message": "來自已關注頻道的推送（未靜音）"
+  },
+  "channel_label": {
+    "message": "頻道"
   }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -1412,9 +1412,13 @@ async function doRefreshPushList(isFromTickle, allowAutoOpenLinks) {
             // also keeps muted senders out of the auto-open path below.
             if (person && person.muted === true) continue;
             const titleOverride = (person && person.name) || push.sender_name || push.sender_email || '';
-            // Unknown senders have no person record yet; synthesize one from
-            // the push's sender fields so getPersonIconDataUrl renders the same
-            // letter avatar the popup will show once the chats refresh lands.
+            // Unknown senders have no person record yet, and therefore no
+            // image_url: synthesize the shape getPersonIconDataUrl expects and
+            // let it fall back to the bundled default avatar (notifications
+            // never draw letter avatars — that is the popup's fillAvatar, see
+            // PERSON_FALLBACK_ICON). email_normalized is the field that earns
+            // its keep: it keys the icon cache, so this entry lines up with the
+            // real record once the chats refresh lands and a photo is fetchable.
             const iconPerson = person || {
               name: push.sender_name,
               email: push.sender_email,
@@ -1446,10 +1450,10 @@ async function doRefreshPushList(isFromTickle, allowAutoOpenLinks) {
             });
           }
 
-          // Device pushes feed the incremental push counter; people pushes are
-          // counted separately by the derived updateChatUnreadCount() below, so
-          // they are awaited here (for completion + side effects) but excluded
-          // from unreadDelta. Both sets run concurrently.
+          // Device and channel pushes feed the incremental push counter; people
+          // pushes are counted separately by the derived updateChatUnreadCount()
+          // below, so they are awaited here (for completion + side effects) but
+          // excluded from unreadDelta. Both sets run concurrently.
           const [deviceResults, peopleResults] = await Promise.all([
             Promise.all(pushesToNotify.map(async push => {
               // Channel / RSS pushes are titled by the feed (their sender_name),
@@ -1533,8 +1537,9 @@ function normalizeOpenUrl(url) {
 // the side effects below, and their failures neither reject nor change it.
 // A people push passes { titleOverride, iconUrl } so the sender names the
 // notification and their avatar (or the fallback icon) is shown; a channel push
-// passes titleOverride alone (the feed's sender_name, default icon); device
-// pushes keep the push title with the default icon. autoOpenLinks is the composed gate
+// passes the feed's sender_name as titleOverride, plus the channel's image as
+// iconUrl when the subscriptions list has one; device pushes keep the push
+// title with the default icon. autoOpenLinks is the composed gate
 // (master / trusted-people): when it is on, link pushes auto-open their url and
 // — only if autoOpenFiles is also on — file pushes auto-open their file_url,
 // mirroring the notification Open button. autoOpenTabActive makes the created
@@ -1735,8 +1740,11 @@ const PERSON_FALLBACK_ICON = 'assets/person128.png';
 // the oldest (insertion order) until the store is within
 // PERSON_AVATAR_CACHE_CAP. Entries are either successes ({ image_url, dataUrl })
 // or negative-cached failures ({ image_url, failed: true }); both kinds count
-// toward the cap. A write failure is swallowed — the avatar was already
-// produced for the caller.
+// toward the cap. The store holds channel icons too, keyed 'channel:<iden>' — a
+// shape no email_normalized can take, so the two kinds can never collide, and
+// the store keeps its name (renaming it would need a migration for zero
+// benefit). A write failure is swallowed — the icon was already produced for
+// the caller.
 async function putPersonAvatar(cache, key, entry) {
   try {
     const next = { ...cache };

--- a/src/background.js
+++ b/src/background.js
@@ -461,6 +461,15 @@ chrome.storage.onChanged.addListener(async (changes, namespace) => {
     }
     await updateChatUnreadCount();
   }
+  // Channel pushes just switched on: the subscriptions list must be in hand
+  // before the first channel push is presented, since the push itself cannot
+  // say whether its channel is muted. Enabling the option is the natural moment
+  // to fetch a list nothing has needed until now. Fire-and-forget;
+  // refreshPeopleFromServer is self-throttled.
+  if (namespace === 'local' && changes.showChannelPushes &&
+      changes.showChannelPushes.newValue === true && changes.showChannelPushes.oldValue !== true) {
+    refreshPeopleFromServer();
+  }
   // Update badge when display settings change
   if (namespace === 'local' && (changes.displayUnreadCounts || changes.displayUnreadPushes || changes.displayUnreadMirrored || changes.displayUnreadChats)) {
     await updateBadge();
@@ -617,6 +626,25 @@ function trimChatToPerson(chat) {
   };
 }
 
+// Trim a subscription down to the fields we store per channel. Written to
+// storage.local only — never to the stale pre-1.11.5 sync copies, which must
+// not gain a list they never had. Deliberately no name: a channel push carries
+// its own feed name in sender_name, which is always current and needs no
+// lookup, so this record exists purely for the two things the push cannot
+// answer — whether the subscription is muted, and what the channel's image is.
+// `iden` is the subscription's own iden, not the channel's; nothing writes it
+// today, but a future mute POST (/v2/subscriptions/{iden}) is the one action
+// that would need it, so it is kept rather than re-fetched later.
+function trimSubscriptionToChannel(subscription) {
+  const channel = subscription.channel || {};
+  return {
+    iden: subscription.iden,
+    channel_iden: channel.iden,
+    image_url: channel.image_url,
+    muted: subscription.muted === true
+  };
+}
+
 // Fetch the devices and people lists from the server when a token exists but
 // the local lists are missing or empty (new machine that received the token
 // via Chrome sync, token saved without running Retrieve).
@@ -720,14 +748,28 @@ let lastPeopleRefreshAttempt = 0;
 // fact; the next refresh, whose request post-dates the write, reconciles.
 let peopleWriteToken = 0;
 
+// Refreshes both tickle-less server lists in one throttled pass: chats (people)
+// and subscriptions (channels). The realtime stream has no subscription tickle
+// either, so channels ride along with people instead of growing a trigger set of
+// their own — they inherit every existing trigger and the 60s throttle above.
+// The name stays refreshPeopleFromServer because all four call sites are people
+// triggers; the channel fetch is a passenger. Each list gets its own helper so
+// that an early return in one (a failed request, a stale write token) abandons
+// that list only and never skips the other.
 async function refreshPeopleFromServer() {
   if (Date.now() - lastPeopleRefreshAttempt < 60 * 1000) return;
   lastPeopleRefreshAttempt = Date.now();
 
   const token = await getAccessToken();
   if (!token) return;
-  const writeTokenAtFetch = peopleWriteToken;
 
+  await Promise.all([
+    refreshPeopleList(token, peopleWriteToken),
+    refreshChannelList(token)
+  ]);
+}
+
+async function refreshPeopleList(token, writeTokenAtFetch) {
   try {
     // ?active=true asks the server to omit deleted chats; the client-side
     // active filter below stays as belt-and-braces.
@@ -746,6 +788,30 @@ async function refreshPeopleFromServer() {
     await chrome.storage.local.set({ people: people, lastPeopleFetch: Date.now() });
   } catch (error) {
     console.error('Failed to refresh people from server:', error);
+  }
+}
+
+// Subscriptions -> the channels list. No write-token dance here: nothing
+// performs targeted local writes to `channels` (the extension is a client — mute
+// lives on pushbullet.com), so a wholesale write has nothing to clobber.
+// lastPeopleFetch is deliberately not stamped from this path: it gates
+// maybeRefreshPeopleOnTabOpen and must keep meaning "the people list was fetched".
+async function refreshChannelList(token) {
+  try {
+    // ?active=true asks the server to omit cancelled subscriptions; the
+    // client-side active filter below stays as belt-and-braces.
+    const response = await fetch('https://api.pushbullet.com/v2/subscriptions?active=true', {
+      headers: { 'Access-Token': token }
+    });
+    if (!response.ok) return;
+
+    const data = await response.json();
+    const channels = (data.subscriptions || [])
+      .filter(subscription => subscription.active === true)
+      .map(trimSubscriptionToChannel);
+    await chrome.storage.local.set({ channels: channels });
+  } catch (error) {
+    console.error('Failed to refresh channels from server:', error);
   }
 }
 
@@ -1106,9 +1172,12 @@ async function handleReconnection() {
 // unhandled (and any future) kinds are skipped everywhere by construction.
 //
 //   'channel'      — a channel / RSS-feed subscription push (channel_iden,
-//                    with the feed's sender_name). Opt-in: shown in the
-//                    Push timeline and notified only while the
-//                    showChannelPushes option is on; always cached.
+//                    with the feed's sender_name). Tested FIRST: the sender_*
+//                    fields of a channel push describe the feed, not a person,
+//                    so any later ordering could misfile it as a chat message.
+//                    Opt-in: shown in the Push timeline and notified only while
+//                    the showChannelPushes option is on and the subscription is
+//                    not muted; always cached.
 //   'people'       — a human wrote to me. sender_email_normalized is also
 //                    the conversation key, so every people push is
 //                    displayable by construction. Chat surface only, and
@@ -1131,6 +1200,17 @@ function classifyPush(push) {
   if (push.direction === 'incoming') return push.sender_email_normalized ? 'people' : 'device';
   if (push.direction === 'outgoing') return push.receiver_email_normalized ? 'conversation' : 'device';
   return 'device'; // unknown direction — fail toward v1.11 visibility
+}
+
+// The stored subscription record for a channel push, or null while the
+// channels list has not caught up (a brand-new subscription, a first run before
+// any fetch). Everything the bubble and the toast title need travels on the
+// push itself; this record answers only "is it muted" and "what is its image",
+// so an unknown channel is simply treated as unmuted and imageless — fail
+// toward showing the push, never toward hiding it.
+// keep in sync with the copy in popup.js
+function findChannelForPush(channels, push) {
+  return (channels || []).find(c => c.channel_iden === push.channel_iden) || null;
 }
 
 // Refreshes run strictly one at a time. Overlapping runs (ws.onopen plus an
@@ -1213,8 +1293,19 @@ async function doRefreshPushList(isFromTickle, allowAutoOpenLinks) {
         if (isFromTickle && newPushes.length > 0) {
           // Apply device filtering for notifications (same as popup display)
           const configData = await chrome.storage.local.get(['onlyBrowserPushes', 'showOtherDevicePushes', 'selectedOtherDeviceIds', 'showNoTargetPushes', 'showChannelPushes', 'autoOpenLinks', 'autoOpenFiles', 'autoOpenTabActive', 'autoOpenLinksFromPeople', 'autoOpenTrustedPeople', 'enableChat', 'hideNotificationOnAutoOpen', 'hideBrowserPushes']);
-          const localData = await chrome.storage.local.get(['chromeDeviceId', 'people']);
+          const localData = await chrome.storage.local.get(['chromeDeviceId', 'people', 'channels']);
           const people = localData.people || [];
+          const channels = localData.channels || [];
+
+          // Unknown channel: refresh the subscriptions list (throttled,
+          // fire-and-forget) so the next push from it can honor its mute flag
+          // and carry its image — the exact analogue of the unknown-sender
+          // refresh in the people loop below. Only while the option is on: a
+          // user who never enables channel pushes must never trigger the fetch.
+          if (configData.showChannelPushes === true &&
+              newPushes.some(push => classifyPush(push) === 'channel' && !findChannelForPush(channels, push))) {
+            refreshPeopleFromServer();
+          }
 
           const pushesToNotify = newPushes.filter(push => {
             const kind = classifyPush(push);
@@ -1222,9 +1313,18 @@ async function doRefreshPushList(isFromTickle, allowAutoOpenLinks) {
             // Channel / RSS pushes are their own opt-in bucket: they carry
             // neither a target nor a source device, so none of the device
             // switches below say anything about them (same rule as the popup
-            // list). Already-dismissed ones stay silent, as in the device lane.
+            // list). A muted subscription is hidden from the timeline as well
+            // as from notifications, deliberately stricter than a muted chat
+            // (notify-only, because the conversation surface must stay
+            // browsable): a channel has no surface of its own and no
+            // in-extension unmute, so a muted channel disappears entirely —
+            // which is what the option label's "(unmuted)" tells the user.
+            // Already-dismissed ones stay silent, as in the device lane.
             if (kind === 'channel') {
-              return configData.showChannelPushes === true && push.dismissed !== true;
+              const channel = findChannelForPush(channels, push);
+              return configData.showChannelPushes === true &&
+                !(channel && channel.muted === true) &&
+                push.dismissed !== true;
             }
 
             // Otherwise only device-tagged pushes use these buckets; people and

--- a/src/background.js
+++ b/src/background.js
@@ -1103,10 +1103,12 @@ async function handleReconnection() {
 
 // classifyPush(push) — the single classifier for every push. Consumers act
 // only on the tag they own; a tag they don't recognize is inert to them, so
-// ignored (and any future) kinds are skipped everywhere by construction.
+// unhandled (and any future) kinds are skipped everywhere by construction.
 //
-//   'ignored'      — channel pushes. Unsupported: kept in the cache
-//                    (faithful server mirror), consumed by no surface.
+//   'channel'      — a channel / RSS-feed subscription push (channel_iden,
+//                    with the feed's sender_name). Opt-in: shown in the
+//                    Push timeline and notified only while the
+//                    showChannelPushes option is on; always cached.
 //   'people'       — a human wrote to me. sender_email_normalized is also
 //                    the conversation key, so every people push is
 //                    displayable by construction. Chat surface only, and
@@ -1124,7 +1126,7 @@ async function handleReconnection() {
 //                    can never vanish and never impersonate a person.
 // keep in sync with the copy in popup.js
 function classifyPush(push) {
-  if (push.channel_iden) return 'ignored';
+  if (push.channel_iden) return 'channel';
   if (push.direction === 'self') return 'device';
   if (push.direction === 'incoming') return push.sender_email_normalized ? 'people' : 'device';
   if (push.direction === 'outgoing') return push.receiver_email_normalized ? 'conversation' : 'device';
@@ -1210,14 +1212,24 @@ async function doRefreshPushList(isFromTickle, allowAutoOpenLinks) {
         // updates when a resume delivers many pushes at once.
         if (isFromTickle && newPushes.length > 0) {
           // Apply device filtering for notifications (same as popup display)
-          const configData = await chrome.storage.local.get(['onlyBrowserPushes', 'showOtherDevicePushes', 'selectedOtherDeviceIds', 'showNoTargetPushes', 'autoOpenLinks', 'autoOpenFiles', 'autoOpenTabActive', 'autoOpenLinksFromPeople', 'autoOpenTrustedPeople', 'enableChat', 'hideNotificationOnAutoOpen', 'hideBrowserPushes']);
+          const configData = await chrome.storage.local.get(['onlyBrowserPushes', 'showOtherDevicePushes', 'selectedOtherDeviceIds', 'showNoTargetPushes', 'showChannelPushes', 'autoOpenLinks', 'autoOpenFiles', 'autoOpenTabActive', 'autoOpenLinksFromPeople', 'autoOpenTrustedPeople', 'enableChat', 'hideNotificationOnAutoOpen', 'hideBrowserPushes']);
           const localData = await chrome.storage.local.get(['chromeDeviceId', 'people']);
           const people = localData.people || [];
 
           const pushesToNotify = newPushes.filter(push => {
-            // Only device-tagged pushes use these buckets; people, conversation,
-            // and ignored (channel) pushes never notify through this lane.
-            if (classifyPush(push) !== 'device') {
+            const kind = classifyPush(push);
+
+            // Channel / RSS pushes are their own opt-in bucket: they carry
+            // neither a target nor a source device, so none of the device
+            // switches below say anything about them (same rule as the popup
+            // list). Already-dismissed ones stay silent, as in the device lane.
+            if (kind === 'channel') {
+              return configData.showChannelPushes === true && push.dismissed !== true;
+            }
+
+            // Otherwise only device-tagged pushes use these buckets; people and
+            // conversation pushes never notify through this lane.
+            if (kind !== 'device') {
               return false;
             }
 
@@ -1338,9 +1350,26 @@ async function doRefreshPushList(isFromTickle, allowAutoOpenLinks) {
           // they are awaited here (for completion + side effects) but excluded
           // from unreadDelta. Both sets run concurrently.
           const [deviceResults, peopleResults] = await Promise.all([
-            Promise.all(pushesToNotify.map(push =>
-              showNotificationForPush(push, configData.autoOpenLinks && allowAutoOpenLinks, configData.hideNotificationOnAutoOpen || false, { autoOpenFiles: configData.autoOpenFiles === true, autoOpenTabActive: configData.autoOpenTabActive === true })
-            )),
+            Promise.all(pushesToNotify.map(push => {
+              // Channel / RSS pushes are titled by the feed (their sender_name),
+              // mirroring the caption on their popup bubble, and never
+              // auto-open: a busy feed would otherwise flood the browser with
+              // tabs the user never asked for, one per item.
+              const isChannel = classifyPush(push) === 'channel';
+              const options = {
+                autoOpenFiles: configData.autoOpenFiles === true,
+                autoOpenTabActive: configData.autoOpenTabActive === true
+              };
+              if (isChannel && push.sender_name) {
+                options.titleOverride = push.sender_name;
+              }
+              return showNotificationForPush(
+                push,
+                !isChannel && configData.autoOpenLinks && allowAutoOpenLinks,
+                configData.hideNotificationOnAutoOpen || false,
+                options
+              );
+            })),
             Promise.all(peopleTasks.map(task => task.promise))
           ]);
 
@@ -1393,8 +1422,9 @@ function normalizeOpenUrl(url) {
 // tallies a whole batch into one counter write, so the decision is made before
 // the side effects below, and their failures neither reject nor change it.
 // A people push passes { titleOverride, iconUrl } so the sender names the
-// notification and their avatar (or the fallback icon) is shown; device pushes
-// keep the push title with the default icon. autoOpenLinks is the composed gate
+// notification and their avatar (or the fallback icon) is shown; a channel push
+// passes titleOverride alone (the feed's sender_name, default icon); device
+// pushes keep the push title with the default icon. autoOpenLinks is the composed gate
 // (master / trusted-people): when it is on, link pushes auto-open their url and
 // — only if autoOpenFiles is also on — file pushes auto-open their file_url,
 // mirroring the notification Open button. autoOpenTabActive makes the created
@@ -1430,8 +1460,9 @@ async function showNotificationForPush(push, autoOpenLinks = false, hideNotifica
         notificationBody = push.body || getMessage('new_push');
       }
 
-      // People pushes name the sender in the title, so the push's own title
-      // (if any) folds onto the first line of the message, mirror-style.
+      // People and channel pushes name their sender (the person / the feed) in
+      // the title, so the push's own title (if any) folds onto the first line
+      // of the message, mirror-style.
       let notificationTitle = push.title || '';
       if (titleOverride !== undefined) {
         notificationTitle = titleOverride;

--- a/src/background.js
+++ b/src/background.js
@@ -1177,7 +1177,8 @@ async function handleReconnection() {
 //                    so any later ordering could misfile it as a chat message.
 //                    Opt-in: shown in the Push timeline and notified only while
 //                    the showChannelPushes option is on and the subscription is
-//                    not muted; always cached.
+//                    not muted; always cached. Past those two gates it behaves
+//                    exactly like a device push, auto-open included.
 //   'people'       — a human wrote to me. sender_email_normalized is also
 //                    the conversation key, so every people push is
 //                    displayable by construction. Chat surface only, and
@@ -1458,8 +1459,6 @@ async function doRefreshPushList(isFromTickle, allowAutoOpenLinks) {
               // needs the list — and either may be absent without disturbing the
               // other: showNotificationForPush keeps the push's own title when
               // titleOverride is absent, and the default icon when iconUrl is.
-              // They never auto-open: a busy feed would otherwise flood the
-              // browser with tabs the user never asked for, one per item.
               const isChannel = classifyPush(push) === 'channel';
               const options = {
                 autoOpenFiles: configData.autoOpenFiles === true,
@@ -1476,7 +1475,7 @@ async function doRefreshPushList(isFromTickle, allowAutoOpenLinks) {
               }
               return showNotificationForPush(
                 push,
-                !isChannel && configData.autoOpenLinks && allowAutoOpenLinks,
+                configData.autoOpenLinks && allowAutoOpenLinks,
                 configData.hideNotificationOnAutoOpen || false,
                 options
               );

--- a/src/background.js
+++ b/src/background.js
@@ -1450,18 +1450,29 @@ async function doRefreshPushList(isFromTickle, allowAutoOpenLinks) {
           // they are awaited here (for completion + side effects) but excluded
           // from unreadDelta. Both sets run concurrently.
           const [deviceResults, peopleResults] = await Promise.all([
-            Promise.all(pushesToNotify.map(push => {
+            Promise.all(pushesToNotify.map(async push => {
               // Channel / RSS pushes are titled by the feed (their sender_name),
-              // mirroring the caption on their popup bubble, and never
-              // auto-open: a busy feed would otherwise flood the browser with
-              // tabs the user never asked for, one per item.
+              // mirroring the caption on their popup bubble, and iconed with the
+              // channel's image where the subscriptions list has one. The two
+              // resolve independently — the title travels on the push, the image
+              // needs the list — and either may be absent without disturbing the
+              // other: showNotificationForPush keeps the push's own title when
+              // titleOverride is absent, and the default icon when iconUrl is.
+              // They never auto-open: a busy feed would otherwise flood the
+              // browser with tabs the user never asked for, one per item.
               const isChannel = classifyPush(push) === 'channel';
               const options = {
                 autoOpenFiles: configData.autoOpenFiles === true,
                 autoOpenTabActive: configData.autoOpenTabActive === true
               };
-              if (isChannel && push.sender_name) {
-                options.titleOverride = push.sender_name;
+              if (isChannel) {
+                if (push.sender_name) {
+                  options.titleOverride = push.sender_name;
+                }
+                const channel = findChannelForPush(channels, push);
+                if (channel && channel.image_url) {
+                  options.iconUrl = await getChannelIconDataUrl(channel);
+                }
               }
               return showNotificationForPush(
                 push,
@@ -1727,14 +1738,14 @@ const PERSON_FALLBACK_ICON = 'assets/person128.png';
 // or negative-cached failures ({ image_url, failed: true }); both kinds count
 // toward the cap. A write failure is swallowed — the avatar was already
 // produced for the caller.
-async function putPersonAvatar(cache, emailNormalized, entry) {
+async function putPersonAvatar(cache, key, entry) {
   try {
     const next = { ...cache };
-    delete next[emailNormalized];
-    next[emailNormalized] = entry;
+    delete next[key];
+    next[key] = entry;
     const keys = Object.keys(next);
-    for (const key of keys.slice(0, Math.max(0, keys.length - PERSON_AVATAR_CACHE_CAP))) {
-      delete next[key];
+    for (const staleKey of keys.slice(0, Math.max(0, keys.length - PERSON_AVATAR_CACHE_CAP))) {
+      delete next[staleKey];
     }
     await chrome.storage.local.set({ personAvatars: next });
   } catch (e) {
@@ -1742,29 +1753,27 @@ async function putPersonAvatar(cache, emailNormalized, entry) {
   }
 }
 
-// Notification avatar for a person. Resolution order:
-//   1. cached success ({ image_url, dataUrl })      -> the cropped photo
-//   2. cached failure ({ image_url, failed: true }) -> the default avatar
-//   3. image_url is an https dl.pushbulletusercontent.com URL -> fetch it; on
-//      success cache + return the photo, on any failure (non-ok / network /
-//      decode) negative-cache the image_url and return the default avatar
-//   4. absent / unparseable / non-whitelisted image_url -> the default avatar
+// Notification icon for a remote image, keyed by cacheKey. Resolution order:
+//   1. cached success ({ image_url, dataUrl })      -> the cropped image
+//   2. cached failure ({ image_url, failed: true }) -> the fallback icon
+//   3. imageUrl is an https dl.pushbulletusercontent.com URL -> fetch it; on
+//      success cache + return the image, on any failure (non-ok / network /
+//      decode) negative-cache the imageUrl and return the fallback icon
+//   4. absent / unparseable / non-whitelisted imageUrl -> the fallback icon
 // Only dl.pushbulletusercontent.com is ever fetched: it is verified to send
 // `access-control-allow-origin: *`. static.pushbullet.com (Google profile
 // photos) sends no CORS headers, so a fetch there can only fail and spam an
 // unsuppressible CORS error onto the extensions page — it, and every other
 // host, is never requested. Cache entries invalidate when image_url changes.
-async function getPersonIconDataUrl(person) {
-  if (!person) return PERSON_FALLBACK_ICON;
-
+async function getRemoteIconDataUrl(cacheKey, imageUrl, fallbackIcon) {
   let cache = {};
   try {
     const stored = await chrome.storage.local.get('personAvatars');
     cache = stored.personAvatars || {};
-    const cached = cache[person.email_normalized];
-    if (cached && cached.image_url === person.image_url) {
-      if (cached.dataUrl) return cached.dataUrl;      // cached success
-      if (cached.failed) return PERSON_FALLBACK_ICON; // cached failure
+    const cached = cache[cacheKey];
+    if (cached && cached.image_url === imageUrl) {
+      if (cached.dataUrl) return cached.dataUrl; // cached success
+      if (cached.failed) return fallbackIcon;    // cached failure
     }
   } catch (e) {
     // Storage read failed; fall through to a fresh attempt.
@@ -1774,9 +1783,9 @@ async function getPersonIconDataUrl(person) {
   // dl.pushbulletusercontent.com. Anything unparseable, http, or any other host
   // (including static.pushbullet.com) never issues a network request.
   let fetchable = false;
-  if (person.image_url) {
+  if (imageUrl) {
     try {
-      const u = new URL(person.image_url);
+      const u = new URL(imageUrl);
       fetchable = u.protocol === 'https:' && u.hostname === 'dl.pushbulletusercontent.com';
     } catch (e) {
       fetchable = false;
@@ -1784,32 +1793,46 @@ async function getPersonIconDataUrl(person) {
   }
 
   if (!fetchable) {
-    return PERSON_FALLBACK_ICON;
+    return fallbackIcon;
   }
 
   try {
-    // Time-bound the request (headers and body both): the people notify loop
-    // awaits this before the batch's device toasts are created, so a hung
-    // download must fail fast rather than stall the notification queue.
-    const resp = await fetch(person.image_url, { signal: AbortSignal.timeout(5000) });
-    if (!resp.ok) throw new Error(`avatar fetch failed: ${resp.status}`);
+    // Time-bound the request (headers and body both): the notify batch awaits
+    // this before its toasts are created, so a hung download must fail fast
+    // rather than stall the notification queue.
+    const resp = await fetch(imageUrl, { signal: AbortSignal.timeout(5000) });
+    if (!resp.ok) throw new Error(`icon fetch failed: ${resp.status}`);
     const blob = await resp.blob();
     const bitmap = await createImageBitmap(blob);
     const dataUrl = await bitmapToCircleDataUrl(bitmap);
-    await putPersonAvatar(cache, person.email_normalized, { image_url: person.image_url, dataUrl });
+    await putPersonAvatar(cache, cacheKey, { image_url: imageUrl, dataUrl });
     return dataUrl;
   } catch (e) {
     // A timeout is transient: fall back for this batch but skip the negative
-    // cache so the photo is retried on the next notification.
+    // cache so the image is retried on the next notification.
     if (e && e.name === 'TimeoutError') {
-      return PERSON_FALLBACK_ICON;
+      return fallbackIcon;
     }
     // Everything else (non-ok, network, decode): negative-cache this image_url
-    // so it is not retried (or re-logged) until it changes, then fall back to
-    // the default avatar.
-    await putPersonAvatar(cache, person.email_normalized, { image_url: person.image_url, failed: true });
-    return PERSON_FALLBACK_ICON;
+    // so it is not retried (or re-logged) until it changes, then fall back.
+    await putPersonAvatar(cache, cacheKey, { image_url: imageUrl, failed: true });
+    return fallbackIcon;
   }
+}
+
+// Notification avatar for a person: their photo, or the bundled default avatar.
+async function getPersonIconDataUrl(person) {
+  return person ? getRemoteIconDataUrl(person.email_normalized, person.image_url, PERSON_FALLBACK_ICON) : PERSON_FALLBACK_ICON;
+}
+
+// Notification icon for a channel: its image, or assets/icon128.png. There is
+// no bundled channel artwork, and that file is already the notification
+// builder's default icon, so an unfetchable channel image degrades to exactly
+// what a normal push toast looks like. The 'channel:' key prefix keeps these
+// entries namespaced away from the email-keyed person avatars in the shared
+// store, which they share the cap with.
+async function getChannelIconDataUrl(channel) {
+  return getRemoteIconDataUrl('channel:' + channel.channel_iden, channel.image_url, 'assets/icon128.png');
 }
 
 // Android identifies an active notification by the (package_name,

--- a/src/options.html
+++ b/src/options.html
@@ -744,6 +744,18 @@
           <div class="toggle-slider"></div>
         </div>
       </div>
+      <!-- Channel / RSS subscriptions have no target device, so they are their
+           own opt-in bucket rather than a case of the three switches above. -->
+      <div class="toggle-container" style="margin-left: 0px;">
+        <label class="toggle-label">
+          <span class="sub-option-icon">↳</span>
+          <span data-i18n="channel_pushes_label">Include Channel/RSS pushes</span>
+        </label>
+        <input type="checkbox" id="showChannelPushes" class="toggle-input">
+        <div class="toggle-switch" id="showChannelPushesToggle">
+          <div class="toggle-slider"></div>
+        </div>
+      </div>
     </div>
 
     <!-- Behavior Tab Content -->

--- a/src/options.html
+++ b/src/options.html
@@ -749,7 +749,7 @@
       <div class="toggle-container" style="margin-left: 0px;">
         <label class="toggle-label">
           <span class="sub-option-icon">↳</span>
-          <span data-i18n="channel_pushes_label">Include Channel/RSS pushes</span>
+          <span data-i18n="channel_pushes_label">From channels you follow (unmuted)</span>
         </label>
         <input type="checkbox" id="showChannelPushes" class="toggle-input">
         <div class="toggle-switch" id="showChannelPushesToggle">

--- a/src/options.js
+++ b/src/options.js
@@ -31,6 +31,8 @@ document.addEventListener('DOMContentLoaded', async function() {
   const showOtherDevicePushesToggle = document.getElementById('showOtherDevicePushesToggle');
   const showNoTargetPushesCheckbox = document.getElementById('showNoTargetPushes');
   const showNoTargetPushesToggle = document.getElementById('showNoTargetPushesToggle');
+  const showChannelPushesCheckbox = document.getElementById('showChannelPushes');
+  const showChannelPushesToggle = document.getElementById('showChannelPushesToggle');
   const hideBrowserPushesCheckbox = document.getElementById('hideBrowserPushes');
   const hideBrowserPushesToggle = document.getElementById('hideBrowserPushesToggle');
   const showSmsShortcutCheckbox = document.getElementById('showSmsShortcut');
@@ -633,7 +635,7 @@ document.addEventListener('DOMContentLoaded', async function() {
     chrome.storage.sync.get(['accessToken', 'userIden'], resolve);
   });
   const localData = await new Promise(resolve => {
-    chrome.storage.local.get(['devices', 'people', 'remoteDeviceId', 'showPerSendTarget', 'enableContextMenu', 'autoOpenLinks', 'autoOpenFiles', 'autoOpenOnResume', 'hideNotificationOnAutoOpen', 'autoOpenLinksFromPeople', 'autoOpenTrustedPeople', 'autoOpenTabActive', 'enableChat', 'notificationMirroring', 'onlyBrowserPushes', 'showOtherDevicePushes', 'showNoTargetPushes', 'hideBrowserPushes', 'showSmsShortcut', 'showQuickShare', 'requireInteraction', 'requireInteractionPushes', 'requireInteractionMirrored', 'requireInteractionChats', 'closeAsDismiss', 'displayUnreadCounts', 'displayUnreadPushes', 'displayUnreadMirrored', 'displayUnreadChats', 'colorMode', 'languageMode', 'defaultTab', 'playSoundOnNotification', 'showOsNotifications', 'selectedOtherDeviceIds'], resolve);
+    chrome.storage.local.get(['devices', 'people', 'remoteDeviceId', 'showPerSendTarget', 'enableContextMenu', 'autoOpenLinks', 'autoOpenFiles', 'autoOpenOnResume', 'hideNotificationOnAutoOpen', 'autoOpenLinksFromPeople', 'autoOpenTrustedPeople', 'autoOpenTabActive', 'enableChat', 'notificationMirroring', 'onlyBrowserPushes', 'showOtherDevicePushes', 'showNoTargetPushes', 'showChannelPushes', 'hideBrowserPushes', 'showSmsShortcut', 'showQuickShare', 'requireInteraction', 'requireInteractionPushes', 'requireInteractionMirrored', 'requireInteractionChats', 'closeAsDismiss', 'displayUnreadCounts', 'displayUnreadPushes', 'displayUnreadMirrored', 'displayUnreadChats', 'colorMode', 'languageMode', 'defaultTab', 'playSoundOnNotification', 'showOsNotifications', 'selectedOtherDeviceIds'], resolve);
   });
   const data = { ...syncData, ...localData };
   
@@ -749,6 +751,12 @@ document.addEventListener('DOMContentLoaded', async function() {
     }
     updateShowOtherDevicePushesToggleVisual();
     updateShowNoTargetPushesToggleVisual();
+
+    // Channel / RSS pushes (default is false/off). Deliberately outside the
+    // migration above: it is a new bucket, never implied by the old
+    // onlyBrowserPushes setting, so existing installs start with it off.
+    showChannelPushesCheckbox.checked = data.showChannelPushes === true;
+    updateShowChannelPushesToggleVisual();
 
     // Load other device selections ('' or unset means all other devices,
     // which the checklist shows as its selected "All other devices" row)
@@ -934,6 +942,11 @@ document.addEventListener('DOMContentLoaded', async function() {
   showNoTargetPushesToggle.addEventListener('click', function() {
     showNoTargetPushesCheckbox.checked = !showNoTargetPushesCheckbox.checked;
     updateShowNoTargetPushesToggleVisual();
+  });
+
+  showChannelPushesToggle.addEventListener('click', function() {
+    showChannelPushesCheckbox.checked = !showChannelPushesCheckbox.checked;
+    updateShowChannelPushesToggleVisual();
   });
 
   hideBrowserPushesToggle.addEventListener('click', function() {
@@ -1484,6 +1497,7 @@ document.addEventListener('DOMContentLoaded', async function() {
       showOtherDevicePushes: showOtherDevicePushesCheckbox.checked,
       selectedOtherDeviceIds: getSelectedOtherDeviceIds(),
       showNoTargetPushes: showNoTargetPushesCheckbox.checked,
+      showChannelPushes: showChannelPushesCheckbox.checked,
       hideBrowserPushes: hideBrowserPushesCheckbox.checked,
       autoOpenLinks: autoOpenLinksCheckbox.checked,
       autoOpenFiles: autoOpenFilesCheckbox.checked,
@@ -1563,6 +1577,7 @@ document.addEventListener('DOMContentLoaded', async function() {
       showOtherDevicePushes: saveData.showOtherDevicePushes,
       selectedOtherDeviceIds: saveData.selectedOtherDeviceIds,
       showNoTargetPushes: saveData.showNoTargetPushes,
+      showChannelPushes: saveData.showChannelPushes,
       hideBrowserPushes: saveData.hideBrowserPushes,
       autoOpenLinks: saveData.autoOpenLinks,
       autoOpenFiles: saveData.autoOpenFiles,
@@ -1841,6 +1856,14 @@ document.addEventListener('DOMContentLoaded', async function() {
       showNoTargetPushesToggle.classList.add('active');
     } else {
       showNoTargetPushesToggle.classList.remove('active');
+    }
+  }
+
+  function updateShowChannelPushesToggleVisual() {
+    if (showChannelPushesCheckbox.checked) {
+      showChannelPushesToggle.classList.add('active');
+    } else {
+      showChannelPushesToggle.classList.remove('active');
     }
   }
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -314,14 +314,31 @@
       text-align: right;
     }
 
-    /* Channel / RSS feed name, above the title of a channel push. Bold but a
-       step smaller and quieter than .message-title, so it reads as the source
-       of the bubble rather than competing with the headline. */
-    .message-sender {
-      font-weight: 600;
-      font-size: 12px;
+    /* Channel / RSS feed name, above the title of a channel push: quieter and a
+       step smaller than .message-title so it reads as the source of the bubble
+       rather than competing with the headline, and led by a feed glyph so a
+       broadcast can't be mistaken for device traffic. The row lives inside the
+       bubble, not on the timestamp line above it: refreshTimestamps()
+       overwrites the textContent of every [data-ts] node once a minute, so
+       anything parked there would silently vanish within 60s of rendering. */
+    .message-channel {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      margin-bottom: 6px;
+      font-size: 11px;
+      line-height: 1.4;
       color: var(--text-secondary);
-      margin-bottom: 3px;
+    }
+
+    .message-channel-icon {
+      width: 12px;
+      height: 12px;
+      flex-shrink: 0;
+    }
+
+    .message-channel-name {
+      font-weight: 600;
       overflow-wrap: anywhere;
     }
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -314,6 +314,17 @@
       text-align: right;
     }
 
+    /* Channel / RSS feed name, above the title of a channel push. Bold but a
+       step smaller and quieter than .message-title, so it reads as the source
+       of the bubble rather than competing with the headline. */
+    .message-sender {
+      font-weight: 600;
+      font-size: 12px;
+      color: var(--text-secondary);
+      margin-bottom: 3px;
+      overflow-wrap: anywhere;
+    }
+
     .message-title {
       font-weight: bold;
       margin-bottom: 5px;

--- a/src/popup.js
+++ b/src/popup.js
@@ -890,11 +890,21 @@ document.addEventListener('DOMContentLoaded', function() {
     // Channel / RSS pushes carry the feed's name in sender_name; it names the
     // bubble above the push's own title (people and device pushes never render
     // a caption here — the Chat header / the Push tab itself is the context).
-    if (classifyPush(push) === 'channel' && push.sender_name) {
-      const senderDiv = document.createElement('div');
-      senderDiv.className = 'message-sender';
-      senderDiv.textContent = push.sender_name;
-      messageDiv.appendChild(senderDiv);
+    // The row renders for every channel push, falling back to the generic word
+    // on the rare push that carries no sender_name, so the glyph always marks a
+    // broadcast as one.
+    if (classifyPush(push) === 'channel') {
+      const channelDiv = document.createElement('div');
+      channelDiv.className = 'message-channel';
+      const channelIcon = document.createElement('span');
+      channelIcon.innerHTML = '<svg class="message-channel-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M6.18,15.64A2.18,2.18 0 0,1 8.36,17.82C8.36,19 7.38,20 6.18,20C5,20 4,19 4,17.82A2.18,2.18 0 0,1 6.18,15.64M4,4.44A15.56,15.56 0 0,1 19.56,20H16.73A12.73,12.73 0 0,0 4,7.27V4.44M4,10.1A9.9,9.9 0 0,1 13.9,20H11.07A7.07,7.07 0 0,0 4,12.93V10.1Z"/></svg>';
+      channelIcon.style.display = 'flex';
+      const channelName = document.createElement('span');
+      channelName.className = 'message-channel-name';
+      channelName.textContent = push.sender_name || window.CustomI18n.getMessage('channel_label');
+      channelDiv.appendChild(channelIcon);
+      channelDiv.appendChild(channelName);
+      messageDiv.appendChild(channelDiv);
     }
 
     if (push.title) {

--- a/src/popup.js
+++ b/src/popup.js
@@ -817,7 +817,8 @@ document.addEventListener('DOMContentLoaded', function() {
   //                    so any later ordering could misfile it as a chat message.
   //                    Opt-in: shown in the Push timeline and notified only while
   //                    the showChannelPushes option is on and the subscription is
-  //                    not muted; always cached.
+  //                    not muted; always cached. Past those two gates it behaves
+  //                    exactly like a device push, auto-open included.
   //   'people'       — a human wrote to me. sender_email_normalized is also
   //                    the conversation key, so every people push is
   //                    displayable by construction. Chat surface only, and

--- a/src/popup.js
+++ b/src/popup.js
@@ -812,9 +812,12 @@ document.addEventListener('DOMContentLoaded', function() {
   // unhandled (and any future) kinds are skipped everywhere by construction.
   //
   //   'channel'      — a channel / RSS-feed subscription push (channel_iden,
-  //                    with the feed's sender_name). Opt-in: shown in the
-  //                    Push timeline and notified only while the
-  //                    showChannelPushes option is on; always cached.
+  //                    with the feed's sender_name). Tested FIRST: the sender_*
+  //                    fields of a channel push describe the feed, not a person,
+  //                    so any later ordering could misfile it as a chat message.
+  //                    Opt-in: shown in the Push timeline and notified only while
+  //                    the showChannelPushes option is on and the subscription is
+  //                    not muted; always cached.
   //   'people'       — a human wrote to me. sender_email_normalized is also
   //                    the conversation key, so every people push is
   //                    displayable by construction. Chat surface only, and
@@ -837,6 +840,16 @@ document.addEventListener('DOMContentLoaded', function() {
     if (push.direction === 'incoming') return push.sender_email_normalized ? 'people' : 'device';
     if (push.direction === 'outgoing') return push.receiver_email_normalized ? 'conversation' : 'device';
     return 'device'; // unknown direction — fail toward v1.11 visibility
+  }
+
+  // The stored subscription record for a channel push, or null while the
+  // channels list has not caught up (a brand-new subscription, a first run
+  // before any fetch). Everything the bubble needs travels on the push itself;
+  // this record answers only "is it muted" — so an unknown channel is simply
+  // treated as unmuted, failing toward showing the push.
+  // keep in sync with the copy in background.js
+  function findChannelForPush(channels, push) {
+    return (channels || []).find(c => c.channel_iden === push.channel_iden) || null;
   }
 
   // Labelled boundary row ("— Unread —") inserted above the first unread item
@@ -981,7 +994,7 @@ document.addEventListener('DOMContentLoaded', function() {
       chrome.storage.local.get('pushes'),
       chrome.storage.local.get('sentMessages'),
       chrome.storage.local.get(['onlyBrowserPushes', 'showOtherDevicePushes', 'selectedOtherDeviceIds', 'showNoTargetPushes', 'showChannelPushes']),
-      chrome.storage.local.get('chromeDeviceId')
+      chrome.storage.local.get(['chromeDeviceId', 'channels'])
     ]);
 
     // Get received messages (filtered by new flexible filtering settings)
@@ -989,15 +1002,21 @@ document.addEventListener('DOMContentLoaded', function() {
     // the filter below.
     const selectedOtherIds = (configData.selectedOtherDeviceIds || '')
       .split(',').map(id => id.trim()).filter(id => id);
+    // Subscriptions list: consulted only for the mute flag — a channel bubble
+    // names itself from the push's own sender_name.
+    const channels = localData.channels || [];
     let receivedMessages = receivedData.pushes || [];
     receivedMessages = receivedMessages.filter(push => {
       const kind = classifyPush(push);
 
       // Channel / RSS pushes are their own opt-in bucket: they have no target
-      // device, so the device switches below say nothing about them (the same
-      // rule the background applies to their notifications). Default is false.
+      // device, so the device switches below say nothing about them. Muted
+      // subscriptions drop out here as well as from notifications — the same
+      // gate the background applies, so list and toasts always agree.
+      // Default is false.
       if (kind === 'channel') {
-        return configData.showChannelPushes === true;
+        const channel = findChannelForPush(channels, push);
+        return configData.showChannelPushes === true && !(channel && channel.muted === true);
       }
 
       // Otherwise only device pushes belong to this timeline; people
@@ -2184,6 +2203,11 @@ document.addEventListener('DOMContentLoaded', function() {
       } else if (currentTab === 'chat') {
         renderPeopleList();
       }
+    }
+    if (areaName === 'local' && changes.channels) {
+      // Subscriptions list landed or changed: repaint the timeline so a newly
+      // muted channel's pushes drop out of it.
+      debouncedLoadMessages();
     }
     if (areaName === 'local' && changes.peopleLastRead && currentTab === 'chat' && chatView === 'list') {
       // Read stamps changed — refresh the list so unread dots clear.

--- a/src/popup.js
+++ b/src/popup.js
@@ -809,10 +809,12 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // classifyPush(push) — the single classifier for every push. Consumers act
   // only on the tag they own; a tag they don't recognize is inert to them, so
-  // ignored (and any future) kinds are skipped everywhere by construction.
+  // unhandled (and any future) kinds are skipped everywhere by construction.
   //
-  //   'ignored'      — channel pushes. Unsupported: kept in the cache
-  //                    (faithful server mirror), consumed by no surface.
+  //   'channel'      — a channel / RSS-feed subscription push (channel_iden,
+  //                    with the feed's sender_name). Opt-in: shown in the
+  //                    Push timeline and notified only while the
+  //                    showChannelPushes option is on; always cached.
   //   'people'       — a human wrote to me. sender_email_normalized is also
   //                    the conversation key, so every people push is
   //                    displayable by construction. Chat surface only, and
@@ -830,7 +832,7 @@ document.addEventListener('DOMContentLoaded', function() {
   //                    can never vanish and never impersonate a person.
   // keep in sync with the copy in background.js
   function classifyPush(push) {
-    if (push.channel_iden) return 'ignored';
+    if (push.channel_iden) return 'channel';
     if (push.direction === 'self') return 'device';
     if (push.direction === 'incoming') return push.sender_email_normalized ? 'people' : 'device';
     if (push.direction === 'outgoing') return push.receiver_email_normalized ? 'conversation' : 'device';
@@ -870,6 +872,16 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const messageDiv = document.createElement('div');
     messageDiv.className = `message ${messageType}`;
+
+    // Channel / RSS pushes carry the feed's name in sender_name; it names the
+    // bubble above the push's own title (people and device pushes never render
+    // a caption here — the Chat header / the Push tab itself is the context).
+    if (classifyPush(push) === 'channel' && push.sender_name) {
+      const senderDiv = document.createElement('div');
+      senderDiv.className = 'message-sender';
+      senderDiv.textContent = push.sender_name;
+      messageDiv.appendChild(senderDiv);
+    }
 
     if (push.title) {
       const titleDiv = document.createElement('div');
@@ -968,7 +980,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const [receivedData, sentData, configData, localData] = await Promise.all([
       chrome.storage.local.get('pushes'),
       chrome.storage.local.get('sentMessages'),
-      chrome.storage.local.get(['onlyBrowserPushes', 'showOtherDevicePushes', 'selectedOtherDeviceIds', 'showNoTargetPushes']),
+      chrome.storage.local.get(['onlyBrowserPushes', 'showOtherDevicePushes', 'selectedOtherDeviceIds', 'showNoTargetPushes', 'showChannelPushes']),
       chrome.storage.local.get('chromeDeviceId')
     ]);
 
@@ -979,10 +991,18 @@ document.addEventListener('DOMContentLoaded', function() {
       .split(',').map(id => id.trim()).filter(id => id);
     let receivedMessages = receivedData.pushes || [];
     receivedMessages = receivedMessages.filter(push => {
-      // Only device pushes belong to this timeline; people ('people'),
-      // sent-to-person ('conversation'), and channel ('ignored') pushes
-      // never render here.
-      if (classifyPush(push) !== 'device') {
+      const kind = classifyPush(push);
+
+      // Channel / RSS pushes are their own opt-in bucket: they have no target
+      // device, so the device switches below say nothing about them (the same
+      // rule the background applies to their notifications). Default is false.
+      if (kind === 'channel') {
+        return configData.showChannelPushes === true;
+      }
+
+      // Otherwise only device pushes belong to this timeline; people
+      // ('people') and sent-to-person ('conversation') pushes never render here.
+      if (kind !== 'device') {
         return false;
       }
 


### PR DESCRIPTION
Channel and RSS feed pushes stopped appearing after they were classified as 'ignored'.
Adds "Include Channel/RSS pushes" under Show pushes (default off). When enabled:

- channel pushes appear in the popup's Push tab and fire notifications
- each is captioned with the feed's `sender_name` above the title
- they are never auto-opened, so a feed can't flood tabs
- Closes #78 

<img width="321" height="400" alt="image" src="https://github.com/user-attachments/assets/0c189e3c-19b6-4ea0-bd24-6de4983704af" />
